### PR TITLE
feat: create loader component and hook ss-041

### DIFF
--- a/src/libs/components/loader/loader.tsx
+++ b/src/libs/components/loader/loader.tsx
@@ -49,7 +49,6 @@ const Loader: React.FC<Properties> = ({
 				hasOverlay ? styles["loader--overlay"] : styles["loader--inline"],
 				className
 			)}
-			{...(hasOverlay && { "aria-modal": true })}
 		>
 			<div className={styles["loader__content"]}>
 				{/* Pulsing decorative squares */}

--- a/src/libs/components/loader/loader.tsx
+++ b/src/libs/components/loader/loader.tsx
@@ -1,7 +1,109 @@
+import { getValidClassNames } from "~/libs/helpers/helpers";
+import { useProgress, useTranslation } from "~/libs/hooks/hooks";
+
 import styles from "./styles.module.css";
 
-const Loader: React.FC = () => {
-	return <div className={styles["loader"]}>Loading...</div>;
+/** SVG ring geometry constants */
+const RING_RADIUS = 44;
+const RING_STROKE_WIDTH = 8;
+const DIAMETER_TO_RADIUS_FACTOR = 2;
+const RING_CIRCUMFERENCE = DIAMETER_TO_RADIUS_FACTOR * Math.PI * RING_RADIUS;
+const STEP = 1;
+const FULL_PROGRESS_FRACTION = 1;
+const PROGRESS_PERCENT_SCALE = 100;
+
+/** Number of pulsing decorative squares */
+const SQUARE_COUNT = 3;
+
+type Properties = {
+	/**
+	 * Extends the root element with custom css classes
+	 */
+	className?: string;
+	/**
+	 * When true the loader renders as a fixed full-screen overlay.
+	 * When false (default) it renders inline with `position: relative`.
+	 */
+	hasOverlay?: boolean;
+	/**
+	 * External controlled progress value (0-100).
+	 * When omitted the internal simulation runs automatically.
+	 */
+	progress?: number;
+};
+
+const Loader: React.FC<Properties> = ({
+	className,
+	hasOverlay = false,
+	progress: externalProgress,
+}) => {
+	const { t } = useTranslation();
+	const { progress } = useProgress(externalProgress);
+
+	const strokeDashoffset =
+		RING_CIRCUMFERENCE * (FULL_PROGRESS_FRACTION - progress / PROGRESS_PERCENT_SCALE);
+
+	return (
+		<div
+			className={getValidClassNames(
+				hasOverlay ? styles["loader--overlay"] : styles["loader--inline"],
+				className
+			)}
+			{...(hasOverlay && { "aria-modal": true })}
+		>
+			<div className={styles["loader__content"]}>
+				{/* Pulsing decorative squares */}
+				{Array.from({ length: SQUARE_COUNT }, (_, index) => {
+					const squareIndexClass = `loader__square--${String(index + STEP)}`;
+
+					return (
+						<span
+							className={getValidClassNames(styles["loader__square"], styles[squareIndexClass])}
+							key={index}
+						/>
+					);
+				})}
+
+				{/* SVG circular progress ring */}
+				<div
+					aria-label={t("common.accessibility.loading")}
+					aria-valuemax={100}
+					aria-valuemin={0}
+					aria-valuenow={progress}
+					className={styles["loader__ring-wrapper"]}
+					role="progressbar"
+				>
+					<svg
+						className={styles["loader__ring-svg"]}
+						viewBox="0 0 100 100"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						{/* Track ring (background) */}
+						<circle
+							className={styles["loader__ring-track"]}
+							cx="50"
+							cy="50"
+							r={RING_RADIUS}
+							strokeWidth={RING_STROKE_WIDTH}
+						/>
+
+						{/* Progress ring (fill) */}
+						<circle
+							className={styles["loader__ring-circle"]}
+							cx="50"
+							cy="50"
+							r={RING_RADIUS}
+							strokeDasharray={RING_CIRCUMFERENCE}
+							strokeDashoffset={strokeDashoffset}
+							strokeWidth={RING_STROKE_WIDTH}
+						/>
+					</svg>
+
+					<span className={styles["loader__ring-label"]}>{Math.round(progress)}%</span>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export { Loader };

--- a/src/libs/components/loader/styles.module.css
+++ b/src/libs/components/loader/styles.module.css
@@ -1,8 +1,139 @@
-.loader {
+/* =========================================
+   Loader — positioning variants
+   ========================================= */
+
+.loader--overlay {
+	position: fixed;
+	inset: 0;
+	z-index: var(--z-index-high);
 	display: flex;
-	justify-content: center;
 	align-items: center;
-	height: 100vh;
-	font-size: 1.5rem;
-	color: var(--color-primary);
+	justify-content: center;
+	background: color-mix(in srgb, var(--color-background-1) 75%, transparent);
+	backdrop-filter: blur(6px);
+	-webkit-backdrop-filter: blur(6px);
+}
+
+.loader--inline {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	min-height: 200px;
+}
+
+/* =========================================
+   Inner content wrapper
+   ========================================= */
+
+.loader__content {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 160px;
+	height: 160px;
+}
+
+/* =========================================
+   Pulsing decorative squares
+   ========================================= */
+
+.loader__square {
+	position: absolute;
+	border-radius: var(--border-radius-md);
+	animation: pulse-square 1.4s ease-in-out infinite;
+	opacity: 0.7;
+}
+
+.loader__square--1 {
+	width: 18px;
+	height: 18px;
+	background: var(--color-background-accent);
+	top: 0;
+	left: calc(50% - 9px);
+	animation-delay: 0s;
+}
+
+.loader__square--2 {
+	width: 14px;
+	height: 14px;
+	background: var(--color-brand);
+	bottom: 10px;
+	left: 12px;
+	animation-delay: 0.15s;
+}
+
+.loader__square--3 {
+	width: 12px;
+	height: 12px;
+	background: var(--color-background-dark);
+	bottom: 10px;
+	right: 12px;
+	animation-delay: 0.3s;
+}
+
+@keyframes pulse-square {
+	0%,
+	100% {
+		transform: scale(1);
+		opacity: 0.7;
+	}
+
+	50% {
+		transform: scale(1.45);
+		opacity: 1;
+	}
+}
+
+/* =========================================
+   SVG ring wrapper
+   ========================================= */
+
+.loader__ring-wrapper {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 120px;
+	height: 120px;
+}
+
+.loader__ring-svg {
+	width: 100%;
+	height: 100%;
+	transform: rotate(-90deg);
+	overflow: visible;
+}
+
+/* =========================================
+   SVG circles
+   ========================================= */
+
+.loader__ring-track {
+	fill: none;
+	stroke: var(--color-background-3);
+	stroke-linecap: round;
+}
+
+.loader__ring-circle {
+	fill: none;
+	stroke: var(--color-background-accent);
+	stroke-linecap: round;
+	transition: stroke-dashoffset 0.25s ease;
+}
+
+/* =========================================
+   Percentage label inside ring
+   ========================================= */
+
+.loader__ring-label {
+	position: absolute;
+	font-family: var(--font-family);
+	font-size: var(--font-size-md);
+	font-weight: 700;
+	color: var(--color-text-primary);
+	letter-spacing: -0.5px;
 }

--- a/src/libs/hooks/hooks.ts
+++ b/src/libs/hooks/hooks.ts
@@ -4,6 +4,7 @@ export { useAudioPlayer } from "./use-audio-player/use-audio-player.hook";
 export { useStopAudioOnUnmount } from "./use-audio-player/use-stop-audio-on-unmount.hook";
 export { useGameFetch } from "./use-game-fetch/use-game-fetch.hook";
 export { useLanguageSync } from "./use-language-sync/use-language-sync.hook";
+export { useProgress } from "./use-progress/use-progress.hook";
 export { useTrueFalseGame } from "./use-true-false-game/use-true-false-game.hook";
 export { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 export { useForm } from "react-hook-form";

--- a/src/libs/hooks/use-progress/libs/types/types.ts
+++ b/src/libs/hooks/use-progress/libs/types/types.ts
@@ -1,0 +1,1 @@
+export { type UseProgressResult } from "./use-progress-result.type";

--- a/src/libs/hooks/use-progress/libs/types/use-progress-result.type.ts
+++ b/src/libs/hooks/use-progress/libs/types/use-progress-result.type.ts
@@ -1,0 +1,5 @@
+type UseProgressResult = {
+	progress: number;
+};
+
+export { type UseProgressResult };

--- a/src/libs/hooks/use-progress/use-progress.hook.ts
+++ b/src/libs/hooks/use-progress/use-progress.hook.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+
+import { type UseProgressResult } from "./libs/types/types";
+
+const PROGRESS_START = 0;
+const PROGRESS_END = 100;
+const PROGRESS_STEP = 1;
+const TICK_INTERVAL_MS = 30;
+
+/**
+ * Simulates a loading progress from 0 to 100.
+ * When an external `value` is provided it acts as a controlled progress source;
+ * when omitted the hook runs an auto-incrementing simulation.
+ *
+ * Switching between controlled (value) and uncontrolled (undefined) modes
+ * at runtime will reset the progress to 0 and restart the simulation.
+ */
+const useProgress = (value?: number): UseProgressResult => {
+	const [progress, setProgress] = useState<number>(PROGRESS_START);
+
+	useEffect(() => {
+		if (value !== undefined) {
+			setProgress(Math.min(PROGRESS_END, Math.max(PROGRESS_START, value)));
+
+			return;
+		}
+
+		setProgress(PROGRESS_START);
+
+		const interval = setInterval(() => {
+			setProgress((previous) => {
+				if (previous >= PROGRESS_END) {
+					clearInterval(interval);
+
+					return PROGRESS_END;
+				}
+
+				return previous + PROGRESS_STEP;
+			});
+		}, TICK_INTERVAL_MS);
+
+		return (): void => {
+			clearInterval(interval);
+		};
+	}, [value]);
+
+	return { progress };
+};
+
+export { useProgress };

--- a/src/libs/modules/localization/locales/en/common.ts
+++ b/src/libs/modules/localization/locales/en/common.ts
@@ -1,4 +1,7 @@
 const common = {
+	accessibility: {
+		loading: "Loading",
+	},
 	button: {
 		playNow: "Play Now",
 		register: "Register Free",

--- a/src/libs/modules/localization/locales/es/common.ts
+++ b/src/libs/modules/localization/locales/es/common.ts
@@ -1,4 +1,7 @@
 const common = {
+	accessibility: {
+		loading: "Cargando",
+	},
 	button: {
 		playNow: "Jugar Ahora",
 		register: "Regístrate Gratis",

--- a/src/libs/modules/localization/locales/uk/common.ts
+++ b/src/libs/modules/localization/locales/uk/common.ts
@@ -1,4 +1,7 @@
 const common = {
+	accessibility: {
+		loading: "Завантаження",
+	},
 	button: {
 		playNow: "Грати зараз",
 		register: "Зареєструватися безкоштовно",

--- a/tests/libs/hooks/use-progress/use-progress.hook.spec.ts
+++ b/tests/libs/hooks/use-progress/use-progress.hook.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useProgress } from "~/libs/hooks/use-progress/use-progress.hook";
+
+// ─── Constants (mirrored from the hook for readability) ───────────────────────
+
+const PROGRESS_START = 0;
+const PROGRESS_END = 100;
+const PROGRESS_STEP = 1;
+const TICK_INTERVAL_MS = 30;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useProgress", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("uncontrolled mode (no value)", () => {
+        it("should start with progress 0", () => {
+            const { result } = renderHook(() => useProgress());
+
+            expect(result.current.progress).toBe(PROGRESS_START);
+        });
+
+        it("should increment progress by 1 every 30ms", () => {
+            const { result } = renderHook(() => useProgress());
+
+            act(() => {
+                vi.advanceTimersByTime(TICK_INTERVAL_MS * 10);
+            });
+
+            expect(result.current.progress).toBe(PROGRESS_STEP * 10);
+        });
+
+        it("should reach 100 after full simulation", () => {
+            const { result } = renderHook(() => useProgress());
+
+            act(() => {
+                vi.advanceTimersByTime(TICK_INTERVAL_MS * PROGRESS_END);
+            });
+
+            expect(result.current.progress).toBe(PROGRESS_END);
+        });
+
+        it("should not exceed 100", () => {
+            const { result } = renderHook(() => useProgress());
+
+            act(() => {
+                vi.advanceTimersByTime(TICK_INTERVAL_MS * (PROGRESS_END + 50));
+            });
+
+            expect(result.current.progress).toBe(PROGRESS_END);
+        });
+
+        it("should clear interval on unmount", () => {
+            const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+            const { unmount } = renderHook(() => useProgress());
+
+            act(() => {
+                vi.advanceTimersByTime(TICK_INTERVAL_MS * 10);
+            });
+
+            unmount();
+
+            expect(clearIntervalSpy).toHaveBeenCalled();
+
+            clearIntervalSpy.mockRestore();
+        });
+    });
+
+    describe("controlled mode (value provided)", () => {
+        it("should return the provided value as progress", () => {
+            const { result } = renderHook(() => useProgress(50));
+
+            expect(result.current.progress).toBe(50);
+        });
+
+        it("should clamp value to 0 when negative value is passed", () => {
+            const { result } = renderHook(() => useProgress(-10));
+
+            expect(result.current.progress).toBe(PROGRESS_START);
+        });
+
+        it("should clamp value to 100 when value exceeds 100", () => {
+            const { result } = renderHook(() => useProgress(150));
+
+            expect(result.current.progress).toBe(PROGRESS_END);
+        });
+
+        it("should update progress when value changes", () => {
+            const { rerender, result } = renderHook(
+                ({ value }: { value: number }) => useProgress(value),
+                { initialProps: { value: 30 } },
+            );
+
+            expect(result.current.progress).toBe(30);
+
+            rerender({ value: 70 });
+
+            expect(result.current.progress).toBe(70);
+        });
+
+        it("should not start interval simulation", () => {
+            const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+            renderHook(() => useProgress(50));
+
+            expect(setIntervalSpy).not.toHaveBeenCalled();
+
+            setIntervalSpy.mockRestore();
+        });
+    });
+
+      describe("mode switching", () => {
+        it("should reset and start simulation when switching from controlled to uncontrolled", () => {
+            const { rerender, result } = renderHook(
+                ({ value }: { value: number | undefined }) => useProgress(value),
+                { initialProps: { value: 50 as number | undefined } },
+            );
+
+            expect(result.current.progress).toBe(50);
+
+            rerender({ value: undefined });
+
+            expect(result.current.progress).toBe(PROGRESS_START);
+
+            act(() => {
+                vi.advanceTimersByTime(TICK_INTERVAL_MS * 20);
+            });
+
+            expect(result.current.progress).toBe(20);
+        });
+
+        it("should stop simulation and use value when switching from uncontrolled to controlled", () => {
+            const { rerender, result } = renderHook(
+                ({ value }: { value: number | undefined }) => useProgress(value),
+                { initialProps: { value: undefined as number | undefined } },
+            );
+
+            act(() => {
+                vi.advanceTimersByTime(TICK_INTERVAL_MS * 10);
+            });
+
+            expect(result.current.progress).toBe(10);
+
+            rerender({ value: 80 });
+
+            expect(result.current.progress).toBe(80);
+
+            act(() => {
+                vi.advanceTimersByTime(TICK_INTERVAL_MS * 50);
+            });
+
+            expect(result.current.progress).toBe(80);
+        });
+    });
+});


### PR DESCRIPTION
 - [x] Create an SVG ring using stroke-dashoffset math to visualize progress (0-100%) and rotate it -90deg to start from the top.
 - [x] Implement hasOverlay logic to switch between fixed full-screen and relative inline positioning.
 - [x] Add three pulsing squares with staggered animation-delay using CSS keyframes.
 - [x] Connect the useProgress hook to the ring and add aria-valuenow for screen reader support.