### PR TITLE
Extract generic use form submit hook: ss-069

### DIFF
--- a/src/libs/hooks/hooks.ts
+++ b/src/libs/hooks/hooks.ts
@@ -2,6 +2,7 @@ export { useAppDispatch } from "./use-app-dispatch/use-app-dispatch.hook";
 export { useAppSelector } from "./use-app-selector/use-app-selector.hook";
 export { useAudioPlayer } from "./use-audio-player/use-audio-player.hook";
 export { useStopAudioOnUnmount } from "./use-audio-player/use-stop-audio-on-unmount.hook";
+export { useFormSubmit } from "./use-form-submit/use-form-submit.hook";
 export { useGameFetch } from "./use-game-fetch/use-game-fetch.hook";
 export { useLanguageSync } from "./use-language-sync/use-language-sync.hook";
 export { useLevelsFetch } from "./use-levels-fetch/use-levels-fetch.hook";

--- a/src/libs/hooks/use-form-submit/use-form-submit.hook.ts
+++ b/src/libs/hooks/use-form-submit/use-form-submit.hook.ts
@@ -1,0 +1,58 @@
+import { type AsyncThunkAction } from "@reduxjs/toolkit";
+import { useCallback } from "react";
+import { type FieldValues, type Path, type UseFormSetError } from "react-hook-form";
+
+import { FIRST_INDEX } from "~/libs/constants/constants";
+import { isThunkErrorPayload } from "~/libs/helpers/helpers";
+import { useAppDispatch } from "~/libs/hooks/hooks";
+import { type AsyncThunkConfig } from "~/libs/types/types";
+
+type Properties<T extends FieldValues, R> = {
+	action: (argument: T) => AsyncThunkAction<R, T, AsyncThunkConfig>;
+	onError?: (() => void) | undefined;
+	onSuccess?: (() => void) | undefined;
+	setError: UseFormSetError<T>;
+};
+
+const useFormSubmit = <T extends FieldValues, R>({
+	action,
+	onError,
+	onSuccess,
+	setError,
+}: Properties<T, R>): ((payload: T) => Promise<void>) => {
+	const dispatch = useAppDispatch();
+
+	const handleFormSubmit = useCallback(
+		async (payload: T): Promise<void> => {
+			const result = await dispatch(action(payload));
+
+			if (result.meta.requestStatus === "rejected") {
+				let hasFieldErrors = false;
+
+				if (isThunkErrorPayload(result.payload) && result.payload.errors) {
+					for (const [field, messages] of Object.entries(result.payload.errors)) {
+						if (Object.hasOwn(payload, field)) {
+							setError(field as Path<T>, {
+								message: messages[FIRST_INDEX] ?? "validation.error",
+							});
+							hasFieldErrors = true;
+						}
+					}
+				}
+
+				if (!hasFieldErrors) {
+					onError?.();
+				}
+
+				return;
+			}
+
+			onSuccess?.();
+		},
+		[action, dispatch, onError, onSuccess, setError],
+	);
+
+	return handleFormSubmit;
+};
+
+export { useFormSubmit };

--- a/src/libs/hooks/use-form-submit/use-form-submit.hook.ts
+++ b/src/libs/hooks/use-form-submit/use-form-submit.hook.ts
@@ -4,7 +4,7 @@ import { type FieldValues, type Path, type UseFormSetError } from "react-hook-fo
 
 import { FIRST_INDEX } from "~/libs/constants/constants";
 import { isThunkErrorPayload } from "~/libs/helpers/helpers";
-import { useAppDispatch } from "~/libs/hooks/hooks";
+import { useAppDispatch } from "~/libs/hooks/use-app-dispatch/use-app-dispatch.hook";
 import { type AsyncThunkConfig } from "~/libs/types/types";
 
 type Properties<T extends FieldValues, R> = {

--- a/src/libs/hooks/use-form-submit/use-form-submit.hook.ts
+++ b/src/libs/hooks/use-form-submit/use-form-submit.hook.ts
@@ -49,7 +49,7 @@ const useFormSubmit = <T extends FieldValues, R>({
 
 			onSuccess?.();
 		},
-		[action, dispatch, onError, onSuccess, setError],
+		[action, dispatch, onError, onSuccess, setError]
 	);
 
 	return handleFormSubmit;

--- a/src/modules/auth/hooks/use-auth-form-submit/use-auth-form-submit.hook.ts
+++ b/src/modules/auth/hooks/use-auth-form-submit/use-auth-form-submit.hook.ts
@@ -1,10 +1,8 @@
 import { type AsyncThunkAction } from "@reduxjs/toolkit";
-import { useCallback } from "react";
 import { type FieldValues, type UseFormSetError } from "react-hook-form";
 
-import { useAppDispatch, useFormSubmit } from "~/libs/hooks/hooks";
+import { useFormSubmit } from "~/libs/hooks/hooks";
 import { type AsyncThunkConfig } from "~/libs/types/types";
-import { actions as authActions } from "~/modules/auth/auth";
 
 type Properties<T extends FieldValues, R> = {
 	action: (argument: T) => AsyncThunkAction<R, T, AsyncThunkConfig>;
@@ -17,16 +15,7 @@ const useAuthFormSubmit = <T extends FieldValues, R>({
 	onSuccess,
 	setError,
 }: Properties<T, R>): ((payload: T) => Promise<void>) => {
-	const dispatch = useAppDispatch();
-	const handleFormSubmit = useFormSubmit({ action, onSuccess, setError });
-
-	return useCallback(
-		async (payload: T): Promise<void> => {
-			dispatch(authActions.clearError());
-			await handleFormSubmit(payload);
-		},
-		[dispatch, handleFormSubmit]
-	);
+	return useFormSubmit({ action, onSuccess, setError });
 };
 
 export { useAuthFormSubmit };

--- a/src/modules/auth/hooks/use-auth-form-submit/use-auth-form-submit.hook.ts
+++ b/src/modules/auth/hooks/use-auth-form-submit/use-auth-form-submit.hook.ts
@@ -25,7 +25,7 @@ const useAuthFormSubmit = <T extends FieldValues, R>({
 			dispatch(authActions.clearError());
 			await handleFormSubmit(payload);
 		},
-		[dispatch, handleFormSubmit],
+		[dispatch, handleFormSubmit]
 	);
 };
 

--- a/src/modules/auth/hooks/use-auth-form-submit/use-auth-form-submit.hook.ts
+++ b/src/modules/auth/hooks/use-auth-form-submit/use-auth-form-submit.hook.ts
@@ -1,10 +1,8 @@
 import { type AsyncThunkAction } from "@reduxjs/toolkit";
 import { useCallback } from "react";
-import { type FieldValues, type Path, type UseFormSetError } from "react-hook-form";
+import { type FieldValues, type UseFormSetError } from "react-hook-form";
 
-import { FIRST_INDEX } from "~/libs/constants/constants";
-import { isThunkErrorPayload } from "~/libs/helpers/helpers";
-import { useAppDispatch } from "~/libs/hooks/hooks";
+import { useAppDispatch, useFormSubmit } from "~/libs/hooks/hooks";
 import { type AsyncThunkConfig } from "~/libs/types/types";
 import { actions as authActions } from "~/modules/auth/auth";
 
@@ -20,33 +18,15 @@ const useAuthFormSubmit = <T extends FieldValues, R>({
 	setError,
 }: Properties<T, R>): ((payload: T) => Promise<void>) => {
 	const dispatch = useAppDispatch();
+	const handleFormSubmit = useFormSubmit({ action, onSuccess, setError });
 
-	const handleFormSubmit = useCallback(
+	return useCallback(
 		async (payload: T): Promise<void> => {
 			dispatch(authActions.clearError());
-
-			const result = await dispatch(action(payload));
-
-			if (result.meta.requestStatus === "rejected") {
-				if (isThunkErrorPayload(result.payload) && result.payload.errors) {
-					for (const [field, messages] of Object.entries(result.payload.errors)) {
-						if (Object.hasOwn(payload, field)) {
-							setError(field as Path<T>, {
-								message: messages[FIRST_INDEX] ?? "validation.error",
-							});
-						}
-					}
-				}
-
-				return;
-			}
-
-			onSuccess?.();
+			await handleFormSubmit(payload);
 		},
-		[action, dispatch, onSuccess, setError]
+		[dispatch, handleFormSubmit],
 	);
-
-	return handleFormSubmit;
 };
 
 export { useAuthFormSubmit };

--- a/src/modules/auth/libs/validation-schemas/auth.validation-schemas.ts
+++ b/src/modules/auth/libs/validation-schemas/auth.validation-schemas.ts
@@ -25,7 +25,7 @@ const loginSchema = z.object({
  * - email: {@link emailSchema}
  * - name: {@link nameSchema}
  * - password: {@link passwordSchema}
- * - password_confirmation: {@link passwordSchema}
+ * - password_confirmation: {@link basicPasswordSchema}
  *
  * Additional checks:
  * - Ensures password and password_confirmation match.

--- a/src/modules/auth/libs/validation-schemas/auth.validation-schemas.ts
+++ b/src/modules/auth/libs/validation-schemas/auth.validation-schemas.ts
@@ -35,7 +35,7 @@ const registerSchema = z
 		email: emailSchema,
 		name: nameSchema,
 		password: passwordSchema,
-		password_confirmation: passwordSchema,
+		password_confirmation: basicPasswordSchema,
 	})
 	.refine((data) => data.password === data.password_confirmation, {
 		message: VALIDATION_MESSAGES.PW_DO_NOT_MATCH,

--- a/src/modules/profile/libs/validation-schemas/update-password.validation-schema.ts
+++ b/src/modules/profile/libs/validation-schemas/update-password.validation-schema.ts
@@ -3,6 +3,17 @@ import { z } from "zod";
 import { VALIDATION_MESSAGES } from "~/libs/constants/constants";
 import { basicPasswordSchema, passwordSchema } from "~/libs/validation-schemas/validation-schemas";
 
+/**
+ * Schema for updating password.
+ * Includes:
+ * - current_password: {@link basicPasswordSchema}
+ * - new_password: {@link passwordSchema}
+ * - new_password_confirmation: {@link basicPasswordSchema}
+ *
+ * Additional checks:
+ * - Ensures new_password and new_password_confirmation match.
+ * - Ensures new_password is different from current_password.
+ */
 const updatePasswordValidationSchema = z
 	.object({
 		current_password: basicPasswordSchema,

--- a/src/modules/profile/libs/validation-schemas/update-password.validation-schema.ts
+++ b/src/modules/profile/libs/validation-schemas/update-password.validation-schema.ts
@@ -7,7 +7,7 @@ const updatePasswordValidationSchema = z
 	.object({
 		current_password: basicPasswordSchema,
 		new_password: passwordSchema,
-		new_password_confirmation: passwordSchema,
+		new_password_confirmation: basicPasswordSchema,
 	})
 	.refine((data) => data.new_password === data.new_password_confirmation, {
 		message: VALIDATION_MESSAGES.PW_DO_NOT_MATCH,

--- a/src/pages/profile-page/components/change-password-form/change-password-form.tsx
+++ b/src/pages/profile-page/components/change-password-form/change-password-form.tsx
@@ -2,9 +2,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 
 import { Button, Input } from "~/libs/components/components";
-import { FIRST_INDEX, VALIDATION_RULES } from "~/libs/constants/constants";
-import { isThunkErrorPayload } from "~/libs/helpers/helpers";
-import { useAppDispatch, useForm, useTranslation } from "~/libs/hooks/hooks";
+import { VALIDATION_RULES } from "~/libs/constants/constants";
+import { useForm, useFormSubmit, useTranslation } from "~/libs/hooks/hooks";
 import {
 	updatePassword,
 	type UpdatePasswordRequestDto,
@@ -15,7 +14,6 @@ import styles from "./styles.module.css";
 
 const ChangePasswordForm: React.FC = () => {
 	const { t } = useTranslation();
-	const dispatch = useAppDispatch();
 
 	const {
 		formState: { errors, isSubmitting },
@@ -32,30 +30,15 @@ const ChangePasswordForm: React.FC = () => {
 		resolver: zodResolver(updatePasswordValidationSchema),
 	});
 
-	const handleFormSubmit = async (payload: UpdatePasswordRequestDto): Promise<void> => {
-		try {
-			await dispatch(updatePassword(payload)).unwrap();
+	const handleFormSubmit = useFormSubmit({
+		action: updatePassword,
+		onError: () => toast.error(t("profile.changePassword.error")),
+		onSuccess: () => {
 			reset();
 			toast.success(t("profile.changePassword.success"));
-		} catch (error) {
-			let hasErrorsSet = false;
-
-			if (isThunkErrorPayload(error) && error.errors) {
-				for (const [field, messages] of Object.entries(error.errors)) {
-					if (field in payload) {
-						setError(field as keyof UpdatePasswordRequestDto, {
-							message: messages[FIRST_INDEX] ?? "profile.changePassword.error",
-						});
-						hasErrorsSet = true;
-					}
-				}
-			}
-
-			if (!hasErrorsSet) {
-				toast.error(t("profile.changePassword.error"));
-			}
-		}
-	};
+		},
+		setError,
+	});
 
 	return (
 		<div className={styles["card"]}>
@@ -89,9 +72,7 @@ const ChangePasswordForm: React.FC = () => {
 				<Input
 					error={
 						errors.new_password_confirmation?.message &&
-						t(errors.new_password_confirmation.message, {
-							min: VALIDATION_RULES.MIN_PASSWORD_LENGTH,
-						})
+						t(errors.new_password_confirmation.message)
 					}
 					iconLeft="lock"
 					label={t("profile.changePassword.fields.confirmPassword.label")}

--- a/src/pages/profile-page/components/change-password-form/change-password-form.tsx
+++ b/src/pages/profile-page/components/change-password-form/change-password-form.tsx
@@ -71,8 +71,7 @@ const ChangePasswordForm: React.FC = () => {
 
 				<Input
 					error={
-						errors.new_password_confirmation?.message &&
-						t(errors.new_password_confirmation.message)
+						errors.new_password_confirmation?.message && t(errors.new_password_confirmation.message)
 					}
 					iconLeft="lock"
 					label={t("profile.changePassword.fields.confirmPassword.label")}

--- a/tests/libs/hooks/use-form-submit/use-form-submit.hook.spec.tsx
+++ b/tests/libs/hooks/use-form-submit/use-form-submit.hook.spec.tsx
@@ -1,0 +1,317 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { configureStore } from "@reduxjs/toolkit";
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useFormSubmit } from "~/libs/hooks/use-form-submit/use-form-submit.hook";
+
+describe("useFormSubmit", () => {
+	const createMockStore = () => {
+		return configureStore({
+			reducer: {
+				_: (state = null) => state,
+			},
+		});
+	};
+
+	const wrapper = ({ children }: { children: React.ReactNode }) => {
+		const store = createMockStore();
+		return <Provider store={store}>{children}</Provider>;
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("calls onSuccess after a fulfilled action", async () => {
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: {},
+			meta: { requestStatus: "fulfilled" },
+		});
+		const onSuccess = vi.fn();
+		const setError = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					onSuccess,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current({ username: "test" });
+
+		expect(onSuccess).toHaveBeenCalled();
+	});
+
+	it("does not call onError after a fulfilled action", async () => {
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: {},
+			meta: { requestStatus: "fulfilled" },
+		});
+		const onError = vi.fn();
+		const setError = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					onError,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current({});
+
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it("does not call onSuccess when action is rejected", async () => {
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: null,
+			meta: { requestStatus: "rejected" },
+		});
+		const onSuccess = vi.fn();
+		const setError = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					onSuccess,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current({});
+
+		expect(onSuccess).not.toHaveBeenCalled();
+	});
+
+	it("calls onError when action is rejected without field errors", async () => {
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: null,
+			meta: { requestStatus: "rejected" },
+		});
+		const onError = vi.fn();
+		const setError = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					onError,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current({});
+
+		expect(onError).toHaveBeenCalled();
+	});
+
+	it("maps backend errors to matching form fields", async () => {
+		const backendErrors = {
+			email: ["Email already exists"],
+			password: ["Password too short"],
+		};
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: { errors: backendErrors },
+			meta: { requestStatus: "rejected" },
+		});
+		const onError = vi.fn();
+		const setError = vi.fn();
+		const payload = { email: "", password: "" };
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					onError,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current(payload);
+
+		expect(setError).toHaveBeenCalledWith("email", {
+			message: "Email already exists",
+		});
+		expect(setError).toHaveBeenCalledWith("password", {
+			message: "Password too short",
+		});
+	});
+
+	it("does not call onError when field errors are mapped", async () => {
+		const backendErrors = {
+			email: ["Email already exists"],
+		};
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: { errors: backendErrors },
+			meta: { requestStatus: "rejected" },
+		});
+		const onError = vi.fn();
+		const setError = vi.fn();
+		const payload = { email: "" };
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					onError,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current(payload);
+
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it("does not set error for fields not present in the payload", async () => {
+		const backendErrors = {
+			unknownField: ["Some error"],
+		};
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: { errors: backendErrors },
+			meta: { requestStatus: "rejected" },
+		});
+		const setError = vi.fn();
+		const payload = { email: "" };
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current(payload);
+
+		expect(setError).not.toHaveBeenCalled();
+	});
+
+	it("calls onError when all rejected errors have unrecognized field names", async () => {
+		const backendErrors = {
+			unknownField: ["Some error"],
+		};
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: { errors: backendErrors },
+			meta: { requestStatus: "rejected" },
+		});
+		const onError = vi.fn();
+		const setError = vi.fn();
+		const payload = { email: "" };
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					onError,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current(payload);
+
+		expect(onError).toHaveBeenCalled();
+	});
+
+	it("uses the first error message from the messages array", async () => {
+		const backendErrors = {
+			email: ["First error", "Second error"],
+		};
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: { errors: backendErrors },
+			meta: { requestStatus: "rejected" },
+		});
+		const setError = vi.fn();
+		const payload = { email: "" };
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current(payload);
+
+		expect(setError).toHaveBeenCalledWith("email", { message: "First error" });
+	});
+
+	it("falls back to 'validation.error' when the messages array is empty", async () => {
+		const backendErrors = {
+			email: [],
+		};
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: { errors: backendErrors },
+			meta: { requestStatus: "rejected" },
+		});
+		const setError = vi.fn();
+		const payload = { email: "" };
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current(payload);
+
+		expect(setError).toHaveBeenCalledWith("email", {
+			message: "validation.error",
+		});
+	});
+
+	it("dispatches the action with the provided payload", async () => {
+		const payload = { username: "testuser", password: "pass123" };
+		const mockAction = vi.fn().mockReturnValue({
+			type: "test/action",
+			payload: {},
+			meta: { requestStatus: "fulfilled" },
+		});
+		const setError = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useFormSubmit({
+					action: mockAction,
+					setError,
+				}),
+			{ wrapper },
+		);
+
+		await result.current(payload);
+
+		expect(mockAction).toHaveBeenCalledWith(payload);
+	});
+});

--- a/tests/modules/auth/hooks/use-auth-form-submit.spec.tsx
+++ b/tests/modules/auth/hooks/use-auth-form-submit.spec.tsx
@@ -6,7 +6,6 @@ import { renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { actions as authActions } from "~/modules/auth/auth";
 import { useAuthFormSubmit } from "~/modules/auth/hooks/use-auth-form-submit/use-auth-form-submit.hook";
 import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
 
@@ -26,31 +25,6 @@ describe("useAuthFormSubmit", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-	});
-
-	it("dispatches clearError before calling the action", async () => {
-		const clearErrorSpy = vi.spyOn(authActions, "clearError");
-		const mockAction = vi.fn().mockReturnValue({
-			type: "auth/test",
-			payload: {},
-			meta: { requestStatus: "fulfilled" },
-		});
-		const setError = vi.fn();
-		const payload = { email: "test@test.com" };
-
-		const { result } = renderHook(
-			() =>
-				useAuthFormSubmit({
-					action: mockAction,
-					setError,
-				}),
-			{ wrapper }
-		);
-
-		await result.current(payload);
-
-		expect(clearErrorSpy).toHaveBeenCalled();
-		expect(mockAction).toHaveBeenCalledWith(payload);
 	});
 
 	it("calls onSuccess after successful submission", async () => {
@@ -75,63 +49,5 @@ describe("useAuthFormSubmit", () => {
 		await result.current({});
 
 		expect(onSuccess).toHaveBeenCalled();
-	});
-
-	it("maps backend errors to form fields correctly", async () => {
-		const backendErrors = {
-			email: ["Email already exists"],
-			password: ["Password too short"],
-		};
-		const mockAction = vi.fn().mockReturnValue({
-			type: "auth/test",
-			payload: { errors: backendErrors },
-			meta: { requestStatus: "rejected" },
-		});
-		const setError = vi.fn();
-		const payload = { email: "", password: "" };
-
-		const { result } = renderHook(
-			() =>
-				useAuthFormSubmit({
-					action: mockAction,
-					setError,
-				}),
-			{ wrapper }
-		);
-
-		await result.current(payload);
-
-		expect(setError).toHaveBeenCalledWith("email", {
-			message: "Email already exists",
-		});
-		expect(setError).toHaveBeenCalledWith("password", {
-			message: "Password too short",
-		});
-	});
-
-	it("does not map errors for fields not present in payload", async () => {
-		const backendErrors = {
-			unknownField: ["Some error"],
-		};
-		const mockAction = vi.fn().mockReturnValue({
-			type: "auth/test",
-			payload: { errors: backendErrors },
-			meta: { requestStatus: "rejected" },
-		});
-		const setError = vi.fn();
-		const payload = { email: "" };
-
-		const { result } = renderHook(
-			() =>
-				useAuthFormSubmit({
-					action: mockAction,
-					setError,
-				}),
-			{ wrapper }
-		);
-
-		await result.current(payload);
-
-		expect(setError).not.toHaveBeenCalled();
 	});
 });

--- a/tests/modules/profile/libs/validation-schemas/update-password.validation-schema.spec.ts
+++ b/tests/modules/profile/libs/validation-schemas/update-password.validation-schema.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { FIRST_INDEX, VALIDATION_MESSAGES } from "~/libs/constants/constants";
+import { updatePasswordValidationSchema } from "~/modules/profile/libs/validation-schemas/update-password.validation-schema";
+
+describe("updatePasswordValidationSchema", () => {
+	it("should pass with valid data", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "OldPassword1",
+			new_password: "NewPassword1",
+			new_password_confirmation: "NewPassword1",
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("should fail when current_password is empty", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "",
+			new_password: "NewPassword1",
+			new_password_confirmation: "NewPassword1",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "current_password",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.PW_REQUIRED);
+		}
+	});
+
+	it("should fail when new_password_confirmation is empty", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "OldPassword1",
+			new_password: "NewPassword1",
+			new_password_confirmation: "",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "new_password_confirmation",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.PW_REQUIRED);
+		}
+	});
+
+	it("should fail when new_password is too short", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "OldPassword1",
+			new_password: "Short1A",
+			new_password_confirmation: "Short1A",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "new_password",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.MIN_PW_LENGTH);
+		}
+	});
+
+	it("should fail when new_password does not contain a number", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "OldPassword1",
+			new_password: "NewPassword",
+			new_password_confirmation: "NewPassword",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "new_password",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.PW_CONTAINS_NUMBER);
+		}
+	});
+
+	it("should fail when new_password does not contain an uppercase letter", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "OldPassword1",
+			new_password: "newpassword1",
+			new_password_confirmation: "newpassword1",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "new_password",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.PW_CONTAINS_UPPERCASE);
+		}
+	});
+
+	it("should fail when new_password does not contain a lowercase letter", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "OldPassword1",
+			new_password: "NEWPASSWORD1",
+			new_password_confirmation: "NEWPASSWORD1",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "new_password",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.PW_CONTAINS_LOWERCASE);
+		}
+	});
+
+	it("should fail when new_password_confirmation does not match new_password", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "OldPassword1",
+			new_password: "NewPassword1",
+			new_password_confirmation: "DifferentPassword1",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "new_password_confirmation",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.PW_DO_NOT_MATCH);
+		}
+	});
+
+	it("should fail when new_password is the same as current_password", () => {
+		const result = updatePasswordValidationSchema.safeParse({
+			current_password: "SamePassword1",
+			new_password: "SamePassword1",
+			new_password_confirmation: "SamePassword1",
+		});
+
+		expect(result.success).toBe(false);
+
+		if (!result.success) {
+			const issue = result.error.issues.find(
+				(i) => i.path[FIRST_INDEX] === "new_password",
+			);
+			expect(issue?.message).toBe(VALIDATION_MESSAGES.PW_MUST_BE_NEW);
+		}
+	});
+});


### PR DESCRIPTION
 - [x] Create src/libs/hooks/use-form-submit/use-form-submit.hook.ts — generic hook with action, setError, onSuccess?, onError? properties
 - [x] Export useFormSubmit from src/libs/hooks/hooks.ts
 - [x] Refactor useAuthFormSubmit to pure delegation: simply configure and return useFormSubmit directly; remove manual clearError dispatch — login.pending and register.pending extraReducers already reset auth.error to null, making the call redundant
 - [x] Replace inline submit logic in ChangePasswordForm with useFormSubmit; remove hasErrorsSet, try/catch, and for...of loop
