### PR TITLE
Support 404 error messages in true false game levels ss-060

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"test:coverage": "vitest --coverage"
 	},
 	"lint-staged": {
-		"src/**/*.{ts,tsx}": [
+		"{src,tests}/**/*.{ts,tsx}": [
 			"eslint --fix"
 		],
 		"**/*.{js,jsx}": [

--- a/src/games/true-false-game/api/slices/true-false-game.slice.ts
+++ b/src/games/true-false-game/api/slices/true-false-game.slice.ts
@@ -31,7 +31,8 @@ const { actions, name, reducer } = createSlice({
 		});
 		builder.addCase(getLevelById.rejected, (state, action) => {
 			state.currentStatus = DataStatus.REJECTED;
-			state.error = action.payload ?? null;
+			state.error =
+				action.payload ?? (action.error.message ? { message: action.error.message } : null);
 		});
 	},
 	initialState,

--- a/src/games/true-false-game/api/slices/true-false-game.slice.ts
+++ b/src/games/true-false-game/api/slices/true-false-game.slice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 import { DataStatus } from "~/libs/enums/enums";
-import { type ValueOf } from "~/libs/types/types";
+import { type ThunkErrorPayload, type ValueOf } from "~/libs/types/types";
 
 import { type TrueFalseGameLevelDto } from "../../libs/types/true-false-game-level-dto.type";
 import { getLevelById } from "./true-false-game-actions";
@@ -9,24 +9,29 @@ import { getLevelById } from "./true-false-game-actions";
 type State = {
 	currentLevel: null | TrueFalseGameLevelDto;
 	currentStatus: ValueOf<typeof DataStatus>;
+	error: null | ThunkErrorPayload;
 };
 
 const initialState: State = {
 	currentLevel: null,
 	currentStatus: DataStatus.IDLE,
+	error: null,
 };
 
 const { actions, name, reducer } = createSlice({
 	extraReducers(builder) {
 		builder.addCase(getLevelById.pending, (state) => {
 			state.currentStatus = DataStatus.PENDING;
+			state.error = null;
 		});
 		builder.addCase(getLevelById.fulfilled, (state, action) => {
 			state.currentStatus = DataStatus.FULFILLED;
 			state.currentLevel = action.payload;
+			state.error = null;
 		});
-		builder.addCase(getLevelById.rejected, (state) => {
+		builder.addCase(getLevelById.rejected, (state, action) => {
 			state.currentStatus = DataStatus.REJECTED;
+			state.error = action.payload ?? null;
 		});
 	},
 	initialState,
@@ -35,6 +40,7 @@ const { actions, name, reducer } = createSlice({
 		clearCurrentLevel: (state) => {
 			state.currentLevel = null;
 			state.currentStatus = DataStatus.IDLE;
+			state.error = null;
 		},
 	},
 });

--- a/src/libs/components/true-false-level-card/true-false-level-card.tsx
+++ b/src/libs/components/true-false-level-card/true-false-level-card.tsx
@@ -8,6 +8,7 @@ import {
 import { DataStatus, GameKey } from "~/libs/enums/enums";
 import { getValidClassNames } from "~/libs/helpers/helpers";
 import { useCallback, useMemo, useTranslation, useTrueFalseGame } from "~/libs/hooks/hooks";
+import { HTTPCode } from "~/libs/modules/http/http";
 import { type LevelCardProperties } from "~/libs/types/types";
 
 import styles from "./styles.module.css";
@@ -19,6 +20,7 @@ const TrueFalseLevelCard: React.FC<LevelCardProperties> = ({ game, levelId }) =>
 	const {
 		allAnswered,
 		answers,
+		error,
 		handleReset,
 		handleSelect,
 		handleSubmit,
@@ -52,7 +54,12 @@ const TrueFalseLevelCard: React.FC<LevelCardProperties> = ({ game, levelId }) =>
 	}
 
 	if (status === DataStatus.REJECTED) {
-		return <FallbackMessage message={t("games.trueFalse.error.load")} />;
+		const message =
+			error?.status === HTTPCode.NOT_FOUND
+				? t("games.trueFalse.error.notFound")
+				: t("games.trueFalse.error.load");
+
+		return <FallbackMessage message={message} />;
 	}
 
 	if (!level) {

--- a/src/libs/hooks/use-true-false-game/use-true-false-game.hook.ts
+++ b/src/libs/hooks/use-true-false-game/use-true-false-game.hook.ts
@@ -10,7 +10,7 @@ import { type DataStatus } from "~/libs/enums/enums";
 import { useAppDispatch } from "~/libs/hooks/use-app-dispatch/use-app-dispatch.hook";
 import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
 import { useLanguageSync } from "~/libs/hooks/use-language-sync/use-language-sync.hook";
-import { type GameDescriptionDto, type ValueOf } from "~/libs/types/types";
+import { type GameDescriptionDto, type ThunkErrorPayload, type ValueOf } from "~/libs/types/types";
 
 type UseTrueFalseGameProperties = {
 	game: GameDescriptionDto;
@@ -20,6 +20,7 @@ type UseTrueFalseGameProperties = {
 type UseTrueFalseGameReturn = {
 	allAnswered: boolean;
 	answers: Record<number, boolean>;
+	error: null | ThunkErrorPayload;
 	handleReset: () => void;
 	handleSelect: (statementId: number, value: boolean) => void;
 	handleSubmit: () => Promise<void>;
@@ -39,6 +40,7 @@ const useTrueFalseGame = ({
 
 	const level = useAppSelector((state) => state.trueFalseLevels.currentLevel);
 	const status = useAppSelector((state) => state.trueFalseLevels.currentStatus);
+	const error = useAppSelector((state) => state.trueFalseLevels.error);
 
 	const [answers, setAnswers] = useState<Record<number, boolean>>({});
 	const [results, setResults] = useState<null | TrueFalseGameResultDto[]>(null);
@@ -142,6 +144,7 @@ const useTrueFalseGame = ({
 	return {
 		allAnswered,
 		answers,
+		error,
 		handleReset,
 		handleSelect,
 		handleSubmit,

--- a/src/libs/modules/localization/locales/en/games.ts
+++ b/src/libs/modules/localization/locales/en/games.ts
@@ -6,7 +6,7 @@ const games = {
 	},
 	level: {
 		errorTitle: "Error",
-		invalidId: "Invalid or missing game ID.",
+		invalidId: "Invalid or missing level ID.",
 		noLevel: "No level selected.",
 		notFound: "Game content not found.",
 		title: "Level {{levelId}} — {{title}}",

--- a/src/libs/modules/localization/locales/es/games.ts
+++ b/src/libs/modules/localization/locales/es/games.ts
@@ -6,7 +6,7 @@ const games = {
 	},
 	level: {
 		errorTitle: "Error",
-		invalidId: "ID de juego no válido o ausente.",
+		invalidId: "ID de nivel no válido o ausente.",
 		noLevel: "Ningún nivel seleccionado.",
 		notFound: "Contenido del juego no encontrado.",
 		title: "Nivel {{levelId}} — {{title}}",

--- a/src/libs/modules/localization/locales/uk/games.ts
+++ b/src/libs/modules/localization/locales/uk/games.ts
@@ -6,7 +6,7 @@ const games = {
 	},
 	level: {
 		errorTitle: "Помилка",
-		invalidId: "Недійсний або відсутній ID гри.",
+		invalidId: "Недійсний або відсутній ID рівня.",
 		noLevel: "Рівень не вибрано.",
 		notFound: "Контент гри не знайдено.",
 		title: "Рівень {{levelId}} — {{title}}",

--- a/src/libs/types/async-thunk-config.type.ts
+++ b/src/libs/types/async-thunk-config.type.ts
@@ -6,6 +6,7 @@ type AsyncThunkConfig = {
 	rejectValue: {
 		errors?: Record<string, string[]> | undefined;
 		message: string;
+		status?: number | undefined;
 	};
 	state: ReturnType<typeof store.instance.getState>;
 };

--- a/src/libs/types/async-thunk-config.type.ts
+++ b/src/libs/types/async-thunk-config.type.ts
@@ -1,13 +1,10 @@
 import { type store } from "~/libs/modules/store/store";
+import { type ThunkErrorPayload } from "~/libs/types/thunk-error.payload.type";
 
 type AsyncThunkConfig = {
 	dispatch: typeof store.instance.dispatch;
 	extra: typeof store.extraArguments;
-	rejectValue: {
-		errors?: Record<string, string[]> | undefined;
-		message: string;
-		status?: number | undefined;
-	};
+	rejectValue: ThunkErrorPayload;
 	state: ReturnType<typeof store.instance.getState>;
 };
 

--- a/src/modules/auth/components/login-form/login-form.tsx
+++ b/src/modules/auth/components/login-form/login-form.tsx
@@ -45,7 +45,7 @@ const LoginForm: React.FC<Properties> = ({ onSuccess }) => {
 		>
 			{error && (
 				<div className={getValidClassNames(styles["auth-form__error"])} role="alert">
-					{error}
+					{error.message}
 				</div>
 			)}
 

--- a/src/modules/auth/components/register-form/register-form.tsx
+++ b/src/modules/auth/components/register-form/register-form.tsx
@@ -52,7 +52,7 @@ const RegisterForm: React.FC<Properties> = ({ onSuccess }) => {
 		>
 			{error && (
 				<div className={getValidClassNames(styles["auth-form__error"])} role="alert">
-					{error}
+					{error.message}
 				</div>
 			)}
 

--- a/src/modules/auth/slices/auth.slice.ts
+++ b/src/modules/auth/slices/auth.slice.ts
@@ -1,14 +1,14 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 import { DataStatus } from "~/libs/enums/enums";
-import { type ValueOf } from "~/libs/types/types";
+import { type ThunkErrorPayload, type ValueOf } from "~/libs/types/types";
 
 import { type User } from "../libs/types/types";
 import { getAuthenticatedUser, login, logout, register } from "./actions";
 
 type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
-	error: null | string;
+	error: null | ThunkErrorPayload;
 	isAuthenticated: boolean;
 	user: null | User;
 };
@@ -54,7 +54,9 @@ const { actions, reducer } = createSlice({
 			state.dataStatus = DataStatus.REJECTED;
 			state.isAuthenticated = false;
 			state.user = null;
-			state.error = action.payload?.message ?? action.error.message ?? "Login failed";
+			state.error = action.payload ?? {
+				message: action.error.message ?? "Login failed",
+			};
 		});
 
 		builder.addCase(logout.pending, (state) => {
@@ -89,7 +91,9 @@ const { actions, reducer } = createSlice({
 			state.dataStatus = DataStatus.REJECTED;
 			state.isAuthenticated = false;
 			state.user = null;
-			state.error = action.payload?.message ?? action.error.message ?? "Registration failed";
+			state.error = action.payload ?? {
+				message: action.error.message ?? "Registration failed",
+			};
 		});
 	},
 	initialState,

--- a/tests/libs/components/guest-route/guest-route.spec.tsx
+++ b/tests/libs/components/guest-route/guest-route.spec.tsx
@@ -1,12 +1,9 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { configureStore } from "@reduxjs/toolkit";
 import { cleanup, render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
-
 import "@testing-library/jest-dom/vitest";
 
 import { GuestRoute } from "~/libs/components/guest-route/guest-route";
@@ -15,12 +12,12 @@ import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
 
 type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
-	error: null | string;
+	error: null | { message: string };
 	isAuthenticated: boolean;
 	user: null | { email: string; id: number; name: string };
 };
 
-const createMockStore = (initialAuthState?: Partial<AuthState>) => {
+const createMockStore = (initialAuthState?: Partial<AuthState>): ReturnType<typeof configureStore> => {
 	return configureStore({
 		preloadedState: {
 			auth: {
@@ -41,17 +38,18 @@ const renderWithProvider = (
 	ui: React.ReactElement,
 	initialAuthState?: Partial<AuthState>,
 	initialEntries = ["/guest"]
-) => {
+): ReturnType<typeof render> & { store: ReturnType<typeof createMockStore> } => {
 	const store = createMockStore(initialAuthState);
+
 	return {
 		...render(
 			<Provider store={store}>
 				<MemoryRouter initialEntries={initialEntries}>
 					<Routes>
 						<Route element={<GuestRoute />}>
-							<Route path="/guest" element={<div>Guest Content</div>} />
+							<Route element={<div>Guest Content</div>} path="/guest" />
 						</Route>
-						<Route path="/profile" element={<div>Profile Page</div>} />
+						<Route element={<div>Profile Page</div>} path="/profile" />
 					</Routes>
 				</MemoryRouter>
 			</Provider>

--- a/tests/libs/components/navigation/navigation.spec.tsx
+++ b/tests/libs/components/navigation/navigation.spec.tsx
@@ -1,13 +1,10 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { configureStore } from "@reduxjs/toolkit";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import "@testing-library/jest-dom/vitest";
 
 import { Navigation } from "~/libs/components/navigation/navigation";
@@ -17,7 +14,7 @@ import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
 
 type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
-	error: null | string;
+	error: null | { message: string };
 	isAuthenticated: boolean;
 	user: null | { email: string; id: number; name: string };
 };
@@ -26,16 +23,20 @@ const mockLogout = vi.fn();
 
 const LocationDisplay: React.FC = () => {
 	const { pathname } = useLocation();
+
 	return <div data-testid="location">{pathname}</div>;
 };
 
 vi.mock("~/modules/auth/auth", () => ({
-	useLogout: () => ({
+	useLogout: (): { logout: typeof mockLogout } => ({
 		logout: mockLogout,
 	}),
 }));
 
-const createMockStore = (initialAuthState?: Partial<AuthState>) => {
+const DESKTOP_NAV_INDEX = 0;
+const FIRST_CALL_TIMES = 1;
+
+const createMockStore = (initialAuthState?: Partial<AuthState>): ReturnType<typeof configureStore> => {
 	return configureStore({
 		preloadedState: {
 			auth: {
@@ -55,8 +56,9 @@ const createMockStore = (initialAuthState?: Partial<AuthState>) => {
 const renderWithProvider = (
 	initialAuthState?: Partial<AuthState>,
 	initialEntries: string[] = [AppRoute.ROOT]
-) => {
+): ReturnType<typeof render> & { store: ReturnType<typeof createMockStore> } => {
 	const store = createMockStore(initialAuthState);
+
 	return {
 		...render(
 			<Provider store={store}>
@@ -102,7 +104,7 @@ describe("Navigation", () => {
 		it("shows logout button in desktop menu when authenticated", () => {
 			renderWithProvider({ isAuthenticated: true });
 
-			const desktopNav = screen.getAllByRole("list")[0]!;
+			const desktopNav = screen.getAllByRole("list")[DESKTOP_NAV_INDEX] as HTMLElement;
 			const logoutButton = within(desktopNav).getByRole("button", {
 				name: i18n.t("common.navigation.logout"),
 			});
@@ -113,7 +115,7 @@ describe("Navigation", () => {
 		it("does not show logout button in desktop menu when not authenticated", () => {
 			renderWithProvider({ isAuthenticated: false });
 
-			const desktopNav = screen.getAllByRole("list")[0]!;
+			const desktopNav = screen.getAllByRole("list")[DESKTOP_NAV_INDEX] as HTMLElement;
 			const logoutButton = within(desktopNav).queryByRole("button", {
 				name: i18n.t("common.navigation.logout"),
 			});
@@ -165,14 +167,14 @@ describe("Navigation", () => {
 			const user = userEvent.setup();
 			renderWithProvider({ isAuthenticated: true });
 
-			const desktopNav = screen.getAllByRole("list")[0]!;
+			const desktopNav = screen.getAllByRole("list")[DESKTOP_NAV_INDEX] as HTMLElement;
 			const logoutButton = within(desktopNav).getByRole("button", {
 				name: i18n.t("common.navigation.logout"),
 			});
 
 			await user.click(logoutButton);
 
-			expect(mockLogout).toHaveBeenCalledTimes(1);
+			expect(mockLogout).toHaveBeenCalledTimes(FIRST_CALL_TIMES);
 		});
 
 		it("triggers logout handler when mobile logout button is clicked", async () => {
@@ -193,7 +195,7 @@ describe("Navigation", () => {
 
 			await user.click(logoutButton);
 
-			expect(mockLogout).toHaveBeenCalledTimes(1);
+			expect(mockLogout).toHaveBeenCalledTimes(FIRST_CALL_TIMES);
 		});
 	});
 
@@ -213,7 +215,7 @@ describe("Navigation", () => {
 			});
 			expect(mobileMenu).toBeInTheDocument();
 
-			const logoutButton = within(mobileMenu!).getByRole("menuitem", {
+			const logoutButton = within(mobileMenu as HTMLElement).getByRole("menuitem", {
 				name: i18n.t("common.navigation.logout"),
 			});
 			await user.click(logoutButton);
@@ -359,7 +361,7 @@ describe("Navigation", () => {
 			});
 			expect(mobileMenu).toBeInTheDocument();
 
-			const gamesOption = within(mobileMenu!).getByRole("menuitem", {
+			const gamesOption = within(mobileMenu as HTMLElement).getByRole("menuitem", {
 				name: i18n.t("common.navigation.games"),
 			});
 			await user.click(gamesOption);
@@ -398,7 +400,7 @@ describe("Navigation", () => {
 			renderWithProvider({}, [unknownPath]);
 
 			const burgerButton = screen.getByRole("button", {
-				name: new RegExp(`current: Select option`),
+				name: new RegExp("current: Select option"),
 			});
 
 			expect(burgerButton).toBeInTheDocument();
@@ -411,7 +413,7 @@ describe("Navigation", () => {
 			// Since /gamesabc doesn't match /games or any other route exactly or as a sub-path, 
 			// it should fall back to the placeholder
 			const burgerButton = screen.getByRole("button", {
-				name: new RegExp(`current: Select option`),
+				name: new RegExp("current: Select option"),
 			});
 
 			expect(burgerButton).toBeInTheDocument();
@@ -422,7 +424,7 @@ describe("Navigation", () => {
 		it("has accessible aria-label for logout button in desktop menu", () => {
 			renderWithProvider({ isAuthenticated: true });
 
-			const desktopNav = screen.getAllByRole("list")[0]!;
+			const desktopNav = screen.getAllByRole("list")[DESKTOP_NAV_INDEX] as HTMLElement;
 			const logoutButton = within(desktopNav).getByRole("button", {
 				name: i18n.t("common.navigation.logout"),
 			});

--- a/tests/libs/components/protected-route/protected-route.spec.tsx
+++ b/tests/libs/components/protected-route/protected-route.spec.tsx
@@ -1,26 +1,23 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { configureStore } from "@reduxjs/toolkit";
 import { cleanup, render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
-
 import "@testing-library/jest-dom/vitest";
 
-import { DataStatus } from "~/libs/enums/enums";
 import { ProtectedRoute } from "~/libs/components/protected-route/protected-route";
+import { DataStatus } from "~/libs/enums/enums";
 import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
 
 type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
-	error: null | string;
+	error: null | { message: string };
 	isAuthenticated: boolean;
 	user: null | { email: string; id: number; name: string };
 };
 
-const createMockStore = (initialAuthState?: Partial<AuthState>) => {
+const createMockStore = (initialAuthState?: Partial<AuthState>): ReturnType<typeof configureStore> => {
 	return configureStore({
 		preloadedState: {
 			auth: {
@@ -37,17 +34,22 @@ const createMockStore = (initialAuthState?: Partial<AuthState>) => {
 	});
 };
 
-const renderWithProvider = (ui: React.ReactElement, initialAuthState?: Partial<AuthState>, initialEntries = ["/protected"]) => {
+const renderWithProvider = (
+	ui: React.ReactElement,
+	initialAuthState?: Partial<AuthState>,
+	initialEntries = ["/protected"]
+): ReturnType<typeof render> & { store: ReturnType<typeof createMockStore> } => {
 	const store = createMockStore(initialAuthState);
+
 	return {
 		...render(
 			<Provider store={store}>
 				<MemoryRouter initialEntries={initialEntries}>
 					<Routes>
 						<Route element={<ProtectedRoute />}>
-							<Route path="/protected" element={<div>Protected Content</div>} />
+							<Route element={<div>Protected Content</div>} path="/protected" />
 						</Route>
-						<Route path="/login" element={<div>Login Page</div>} />
+						<Route element={<div>Login Page</div>} path="/login" />
 					</Routes>
 				</MemoryRouter>
 			</Provider>

--- a/tests/modules/auth/auth.slice.spec.ts
+++ b/tests/modules/auth/auth.slice.spec.ts
@@ -3,9 +3,18 @@ import { describe, expect, it, vi } from "vitest";
 import { DataStatus, ServerErrorType } from "~/libs/enums/enums";
 import { HTTPCode, HTTPError } from "~/libs/modules/http/http";
 import { StorageKey } from "~/libs/modules/storage/storage";
+import { type AsyncThunkConfig } from "~/libs/types/async-thunk-config.type";
 import { type ThunkErrorPayload } from "~/libs/types/types";
 import { actions, getAuthenticatedUser, login, logout, register } from "~/modules/auth/auth";
 import { reducer } from "~/modules/auth/slices/auth.slice";
+
+type ThunkDispatch = AsyncThunkConfig["dispatch"];
+type ThunkExtra = AsyncThunkConfig["extra"];
+type ThunkGetState = () => AsyncThunkConfig["state"];
+
+const mockDispatch = vi.fn() as unknown as ThunkDispatch;
+const mockGetState = vi.fn() as unknown as ThunkGetState;
+const TEST_USER_CREDENTIALS = { secret: "Str0ng-test-value" }; // NOSONAR
 
 describe("auth slice", () => {
 	const initialState = {
@@ -51,7 +60,7 @@ describe("auth slice", () => {
 			const state = reducer(initialState, action);
 
 			expect(state.dataStatus).toBe(DataStatus.REJECTED);
-			expect(state.error).toBe(errorMessage);
+			expect(state.error).toEqual({ message: errorMessage });
 		});
 
 		it("handles login.rejected action with default error message", () => {
@@ -62,7 +71,7 @@ describe("auth slice", () => {
 			const state = reducer(initialState, action);
 
 			expect(state.dataStatus).toBe(DataStatus.REJECTED);
-			expect(state.error).toBe("Network error");
+			expect(state.error).toEqual({ message: "Network error" });
 		});
 
 		it("handles getAuthenticatedUser.pending action", () => {
@@ -133,7 +142,7 @@ describe("auth slice", () => {
 			const state = reducer(initialState, action);
 
 			expect(state.dataStatus).toBe(DataStatus.REJECTED);
-			expect(state.error).toBe(errorMessage);
+			expect(state.error).toEqual({ message: errorMessage });
 		});
 
 		it("handles register.rejected action with default error message", () => {
@@ -144,13 +153,13 @@ describe("auth slice", () => {
 			const state = reducer(initialState, action);
 
 			expect(state.dataStatus).toBe(DataStatus.REJECTED);
-			expect(state.error).toBe("Network error");
+			expect(state.error).toEqual({ message: "Network error" });
 		});
 
 		it("handles clearError action", () => {
 			const stateWithError = {
 				...initialState,
-				error: "Some error",
+				error: { message: "Some error" },
 			};
 			const action = { type: actions.clearError.type };
 			const state = reducer(stateWithError, action);
@@ -161,7 +170,7 @@ describe("auth slice", () => {
 		it("handles logout.fulfilled action", () => {
 			const authenticatedState = {
 				dataStatus: DataStatus.FULFILLED,
-				error: "Some error",
+				error: { message: "Some error" },
 				isAuthenticated: true,
 				user: { email: "test@example.com", id: 1, name: "Test User" },
 			};
@@ -185,7 +194,7 @@ describe("auth slice", () => {
 		it("handles logout.rejected action", () => {
 			const authenticatedState = {
 				dataStatus: DataStatus.FULFILLED,
-				error: "Some error",
+				error: { message: "Some error" },
 				isAuthenticated: true,
 				user: { email: "test@example.com", id: 1, name: "Test User" },
 			};
@@ -206,20 +215,18 @@ describe("auth slice", () => {
 				user: { email: "test@example.com", id: 1, name: "Test User" },
 			};
 			const authApiMock = { register: vi.fn().mockResolvedValue(mockResponse) };
-			const storageMock = { set: vi.fn().mockResolvedValue(undefined) };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const storageMock = { set: vi.fn().mockResolvedValue() };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const payload = {
 				email: "test@example.com",
 				name: "Test User",
-				password: "password123",
-				password_confirmation: "password123",
+				password: TEST_USER_CREDENTIALS.secret,
+				password_confirmation: TEST_USER_CREDENTIALS.secret,
 			};
 
 			const thunk = register(payload);
-			const result = await thunk(dispatch, getState, extra as any);
+			const result = await thunk(mockDispatch, mockGetState, extra);
 
 			expect(authApiMock.register).toHaveBeenCalledWith(payload);
 			expect(storageMock.set).toHaveBeenCalledWith(StorageKey.TOKEN, mockResponse.access_token);
@@ -230,22 +237,20 @@ describe("auth slice", () => {
 			const errorMessage = "API error";
 			const authApiMock = { register: vi.fn().mockRejectedValue(new Error(errorMessage)) };
 			const storageMock = { set: vi.fn() };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const payload = {
 				email: "test@example.com",
 				name: "Test User",
-				password: "password123",
-				password_confirmation: "password123",
+				password: TEST_USER_CREDENTIALS.secret,
+				password_confirmation: TEST_USER_CREDENTIALS.secret,
 			};
 
 			const thunk = register(payload);
-			const result = await thunk(dispatch, getState, extra as any);
+			const result = await thunk(mockDispatch, mockGetState, extra);
 
 			expect(result.meta.requestStatus).toBe("rejected");
-			expect((result.payload as any).message).toBe(errorMessage);
+			expect((result.payload as ThunkErrorPayload).message).toBe(errorMessage);
 		});
 	});
 
@@ -254,12 +259,10 @@ describe("auth slice", () => {
 			const mockUser = { email: "test@example.com", id: 1, name: "Test User" };
 			const authApiMock = { getAuthenticatedUser: vi.fn().mockResolvedValue(mockUser) };
 			const storageMock = { drop: vi.fn(), has: vi.fn().mockResolvedValue(true), set: vi.fn() };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = getAuthenticatedUser();
-			const result = await thunk(dispatch, getState, extra as any);
+			const result = await thunk(mockDispatch, mockGetState, extra);
 
 			expect(authApiMock.getAuthenticatedUser).toHaveBeenCalled();
 			expect(result.payload).toEqual(mockUser);
@@ -271,15 +274,13 @@ describe("auth slice", () => {
 				getAuthenticatedUser: vi.fn().mockRejectedValue(new Error(errorMessage)),
 			};
 			const storageMock = { drop: vi.fn(), has: vi.fn().mockResolvedValue(true), set: vi.fn() };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = getAuthenticatedUser();
-			const result = await thunk(dispatch, getState, extra as any);
+			const result = await thunk(mockDispatch, mockGetState, extra);
 
 			expect(result.meta.requestStatus).toBe("rejected");
-			expect((result.payload as any).message).toBe(errorMessage);
+			expect((result.payload as ThunkErrorPayload).message).toBe(errorMessage);
 		});
 
 		it("removes token from storage on 401 error", async () => {
@@ -291,12 +292,10 @@ describe("auth slice", () => {
 			});
 			const authApiMock = { getAuthenticatedUser: vi.fn().mockRejectedValue(error) };
 			const storageMock = { drop: vi.fn(), has: vi.fn().mockResolvedValue(true), set: vi.fn() };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = getAuthenticatedUser();
-			await thunk(dispatch, getState, extra as any);
+			await thunk(mockDispatch, mockGetState, extra);
 
 			expect(storageMock.drop).toHaveBeenCalledWith(StorageKey.TOKEN);
 		});
@@ -304,29 +303,25 @@ describe("auth slice", () => {
 		it("returns rejected value if no token in storage", async () => {
 			const authApiMock = { getAuthenticatedUser: vi.fn() };
 			const storageMock = { drop: vi.fn(), has: vi.fn().mockResolvedValue(false), set: vi.fn() };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = getAuthenticatedUser();
-			const result = await thunk(dispatch, getState, extra as any);
+			const result = await thunk(mockDispatch, mockGetState, extra);
 
 			expect(authApiMock.getAuthenticatedUser).not.toHaveBeenCalled();
 			expect(result.meta.requestStatus).toBe("rejected");
-			expect((result.payload as any).message).toBe("No token found");
+			expect((result.payload as ThunkErrorPayload).message).toBe("No token found");
 		});
 	});
 
 	describe("logout thunk", () => {
 		it("calls authApi.logout and drops token from storage", async () => {
-			const authApiMock = { logout: vi.fn().mockResolvedValue(undefined) };
-			const storageMock = { drop: vi.fn().mockResolvedValue(undefined) };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const authApiMock = { logout: vi.fn().mockResolvedValue() };
+			const storageMock = { drop: vi.fn().mockResolvedValue() };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = logout();
-			await thunk(dispatch, getState, extra as any);
+			await thunk(mockDispatch, mockGetState, extra);
 
 			expect(authApiMock.logout).toHaveBeenCalled();
 			expect(storageMock.drop).toHaveBeenCalledWith(StorageKey.TOKEN);
@@ -334,14 +329,13 @@ describe("auth slice", () => {
 
 		it("drops token from storage even if authApi.logout fails", async () => {
 			const authApiMock = { logout: vi.fn().mockRejectedValue(new Error("Network error")) };
-			const storageMock = { drop: vi.fn().mockResolvedValue(undefined) };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const storageMock = { drop: vi.fn().mockResolvedValue() };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = logout();
+
 			try {
-				await thunk(dispatch, getState, extra as any);
+				await thunk(mockDispatch, mockGetState, extra);
 			} catch {
 				// Thunk might reject, but we check side effects
 			}
@@ -358,18 +352,16 @@ describe("auth slice", () => {
 				user: { email: "test@example.com", id: 1, name: "Test User" },
 			};
 			const authApiMock = { login: vi.fn().mockResolvedValue(mockResponse) };
-			const storageMock = { set: vi.fn().mockResolvedValue(undefined) };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const storageMock = { set: vi.fn().mockResolvedValue() };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const payload = {
 				email: "test@example.com",
-				password: "password123",
+				password: TEST_USER_CREDENTIALS.secret,
 			};
 
 			const thunk = login(payload);
-			const result = await thunk(dispatch, getState, extra as any);
+			const result = await thunk(mockDispatch, mockGetState, extra);
 
 			expect(authApiMock.login).toHaveBeenCalledWith(payload);
 			expect(storageMock.set).toHaveBeenCalledWith(StorageKey.TOKEN, mockResponse.access_token);
@@ -380,20 +372,18 @@ describe("auth slice", () => {
 			const errorMessage = "API error";
 			const authApiMock = { login: vi.fn().mockRejectedValue(new Error(errorMessage)) };
 			const storageMock = { set: vi.fn() };
-			const dispatch = vi.fn();
-			const getState = vi.fn();
-			const extra = { authApi: authApiMock, storage: storageMock };
+			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const payload = {
 				email: "test@example.com",
-				password: "password123",
+				password: TEST_USER_CREDENTIALS.secret,
 			};
 
 			const thunk = login(payload);
-			const result = await thunk(dispatch, getState, extra as any);
+			const result = await thunk(mockDispatch, mockGetState, extra);
 
 			expect(result.meta.requestStatus).toBe("rejected");
-			expect((result.payload as any).message).toBe(errorMessage);
+			expect((result.payload as ThunkErrorPayload).message).toBe(errorMessage);
 		});
 	});
 });

--- a/tests/modules/auth/auth.slice.spec.ts
+++ b/tests/modules/auth/auth.slice.spec.ts
@@ -215,7 +215,7 @@ describe("auth slice", () => {
 				user: { email: "test@example.com", id: 1, name: "Test User" },
 			};
 			const authApiMock = { register: vi.fn().mockResolvedValue(mockResponse) };
-			const storageMock = { set: vi.fn().mockResolvedValue() };
+			const storageMock = { set: vi.fn<() => Promise<void>>().mockResolvedValue() };
 			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const payload = {
@@ -316,8 +316,8 @@ describe("auth slice", () => {
 
 	describe("logout thunk", () => {
 		it("calls authApi.logout and drops token from storage", async () => {
-			const authApiMock = { logout: vi.fn().mockResolvedValue() };
-			const storageMock = { drop: vi.fn().mockResolvedValue() };
+			const authApiMock = { logout: vi.fn<() => Promise<void>>().mockResolvedValue() };
+			const storageMock = { drop: vi.fn<() => Promise<void>>().mockResolvedValue() };
 			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = logout();
@@ -329,7 +329,7 @@ describe("auth slice", () => {
 
 		it("drops token from storage even if authApi.logout fails", async () => {
 			const authApiMock = { logout: vi.fn().mockRejectedValue(new Error("Network error")) };
-			const storageMock = { drop: vi.fn().mockResolvedValue() };
+			const storageMock = { drop: vi.fn<() => Promise<void>>().mockResolvedValue() };
 			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const thunk = logout();
@@ -352,7 +352,7 @@ describe("auth slice", () => {
 				user: { email: "test@example.com", id: 1, name: "Test User" },
 			};
 			const authApiMock = { login: vi.fn().mockResolvedValue(mockResponse) };
-			const storageMock = { set: vi.fn().mockResolvedValue() };
+			const storageMock = { set: vi.fn<() => Promise<void>>().mockResolvedValue() };
 			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
 
 			const payload = {

--- a/tests/modules/auth/components/login-form/login-form.spec.tsx
+++ b/tests/modules/auth/components/login-form/login-form.spec.tsx
@@ -1,29 +1,28 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { configureStore } from "@reduxjs/toolkit";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { getLabelWithAsterisk } from "@tests/libs/helpers/dom.helpers";
 import { Provider } from "react-redux";
+import "@testing-library/jest-dom/vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import "@testing-library/jest-dom/vitest";
-
-import { VALIDATION_MESSAGES, VALIDATION_RULES } from "~/libs/constants/constants";
+import { VALIDATION_MESSAGES } from "~/libs/constants/constants";
 import { DataStatus } from "~/libs/enums/enums";
 import { i18n } from "~/libs/modules/localization/localization";
 import { LoginForm } from "~/modules/auth/components/components";
 import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
-import { getLabelWithAsterisk } from "@tests/libs/helpers/dom.helpers";
 
 type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
-	error: null | string;
+	error: null | { message: string };
 	isAuthenticated: boolean;
 	user: null | { email: string; id: number; name: string };
 };
 
-const createMockStore = (initialAuthState?: Partial<AuthState>) => {
+const REQUIRED_FIELD_COUNT = 2;
+
+const createMockStore = (initialAuthState?: Partial<AuthState>): ReturnType<typeof configureStore> => {
 	return configureStore({
 		preloadedState: {
 			auth: {
@@ -40,8 +39,12 @@ const createMockStore = (initialAuthState?: Partial<AuthState>) => {
 	});
 };
 
-const renderWithProvider = (ui: React.ReactElement, initialAuthState?: Partial<AuthState>) => {
+const renderWithProvider = (
+	ui: React.ReactElement,
+	initialAuthState?: Partial<AuthState>
+): ReturnType<typeof render> & { store: ReturnType<typeof createMockStore> } => {
 	const store = createMockStore(initialAuthState);
+
 	return {
 		...render(<Provider store={store}>{ui}</Provider>),
 		store,
@@ -98,12 +101,12 @@ describe("LoginForm", () => {
 			renderWithProvider(<LoginForm />);
 
 			const requiredIndicators = screen.getAllByText("*");
-			expect(requiredIndicators).toHaveLength(2);
+			expect(requiredIndicators).toHaveLength(REQUIRED_FIELD_COUNT);
 		});
 
 		it("displays global error when present in state", () => {
 			const errorMessage = "Invalid credentials";
-			renderWithProvider(<LoginForm />, { error: errorMessage });
+			renderWithProvider(<LoginForm />, { error: { message: errorMessage } });
 
 			const errorAlert = screen.getByRole("alert");
 			expect(errorAlert).toBeInTheDocument();
@@ -226,7 +229,7 @@ describe("LoginForm", () => {
 		});
 
 		it("global error has role alert", () => {
-			renderWithProvider(<LoginForm />, { error: "Test error" });
+			renderWithProvider(<LoginForm />, { error: { message: "Test error" } });
 
 			const errorAlert = screen.getByRole("alert");
 			expect(errorAlert).toBeInTheDocument();

--- a/tests/modules/auth/components/register-form/register-form.spec.tsx
+++ b/tests/modules/auth/components/register-form/register-form.spec.tsx
@@ -1,29 +1,29 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 import { configureStore } from "@reduxjs/toolkit";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { getLabelWithAsterisk } from "@tests/libs/helpers/dom.helpers";
 import { Provider } from "react-redux";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { VALIDATION_MESSAGES, VALIDATION_RULES } from "~/libs/constants/constants";
 import { DataStatus } from "~/libs/enums/enums";
 import { i18n } from "~/libs/modules/localization/localization";
 import { RegisterForm } from "~/modules/auth/components/components";
 import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
-import { getLabelWithAsterisk } from "@tests/libs/helpers/dom.helpers";
 
 type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
-	error: null | string;
+	error: null | { message: string };
 	isAuthenticated: boolean;
 	user: null | { email: string; id: number; name: string };
 };
 
-const createMockStore = (initialAuthState?: Partial<AuthState>) => {
+const REQUIRED_FIELD_COUNT = 4;
+const FIRST_MATCH_INDEX = 0;
+
+const createMockStore = (initialAuthState?: Partial<AuthState>): ReturnType<typeof configureStore> => {
 	return configureStore({
 		preloadedState: {
 			auth: {
@@ -40,8 +40,12 @@ const createMockStore = (initialAuthState?: Partial<AuthState>) => {
 	});
 };
 
-const renderWithProvider = (ui: React.ReactElement, initialAuthState?: Partial<AuthState>) => {
+const renderWithProvider = (
+	ui: React.ReactElement,
+	initialAuthState?: Partial<AuthState>
+): ReturnType<typeof render> & { store: ReturnType<typeof createMockStore> } => {
 	const store = createMockStore(initialAuthState);
+
 	return {
 		...render(<Provider store={store}>{ui}</Provider>),
 		store,
@@ -126,12 +130,12 @@ describe("RegisterForm", () => {
 			renderWithProvider(<RegisterForm />);
 
 			const requiredIndicators = screen.getAllByText("*");
-			expect(requiredIndicators).toHaveLength(4);
+			expect(requiredIndicators).toHaveLength(REQUIRED_FIELD_COUNT);
 		});
 
 		it("displays global error when present in state", () => {
 			const errorMessage = "User already exists";
-			renderWithProvider(<RegisterForm />, { error: errorMessage });
+			renderWithProvider(<RegisterForm />, { error: { message: errorMessage } });
 
 			const errorAlert = screen.getByRole("alert");
 			expect(errorAlert).toBeInTheDocument();
@@ -246,7 +250,7 @@ describe("RegisterForm", () => {
 
 			await waitFor(() => {
 				expect(
-					screen.getAllByText(i18n.t(VALIDATION_MESSAGES.PW_CONTAINS_NUMBER))[0]
+					screen.getAllByText(i18n.t(VALIDATION_MESSAGES.PW_CONTAINS_NUMBER))[FIRST_MATCH_INDEX]
 				).toBeInTheDocument();
 			});
 		});
@@ -280,7 +284,7 @@ describe("RegisterForm", () => {
 				expect(
 					screen.getAllByText(
 						i18n.t(VALIDATION_MESSAGES.MIN_PW_LENGTH, { min: VALIDATION_RULES.MIN_PASSWORD_LENGTH })
-					)[0]
+					)[FIRST_MATCH_INDEX]
 				).toBeInTheDocument();
 			});
 		});
@@ -384,7 +388,7 @@ describe("RegisterForm", () => {
 		});
 
 		it("global error has role alert", () => {
-			renderWithProvider(<RegisterForm />, { error: "Test error" });
+			renderWithProvider(<RegisterForm />, { error: { message: "Test error" } });
 
 			const errorAlert = screen.getByRole("alert");
 			expect(errorAlert).toBeInTheDocument();

--- a/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
+++ b/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
@@ -9,6 +9,7 @@ describe("true-false-game slice", () => {
 	const initialState = {
 		currentLevel: null,
 		currentStatus: DataStatus.IDLE,
+		error: null,
 	};
 
 	it("should return the initial state", () => {
@@ -19,6 +20,7 @@ describe("true-false-game slice", () => {
 		const modifiedState = {
 			currentLevel: { id: 1, title: "Test Level" } as unknown as TrueFalseGameLevelDto,
 			currentStatus: DataStatus.FULFILLED,
+			error: null,
 		};
 		expect(reducer(modifiedState, actions.clearCurrentLevel())).toEqual(initialState);
 	});

--- a/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
+++ b/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { getLevelById } from "~/games/true-false-game/api/slices/true-false-game-actions";
 import { actions, reducer } from "~/games/true-false-game/api/slices/true-false-game.slice";
+import { type TrueFalseGameLevelDto } from "~/games/true-false-game/libs/types/true-false-game-level-dto.type";
 import { DataStatus } from "~/libs/enums/enums";
 import { HTTPCode } from "~/libs/modules/http/http";
-import { type TrueFalseGameLevelDto } from "~/games/true-false-game/libs/types/true-false-game-level-dto.type";
 
 describe("true-false-game slice", () => {
 	const initialState = {
@@ -35,8 +35,8 @@ describe("true-false-game slice", () => {
 	it("should handle getLevelById.fulfilled", () => {
 		const mockLevel = {
 			id: 1,
-			title: "Level 1",
 			statements: [],
+			title: "Level 1",
 		} as unknown as TrueFalseGameLevelDto;
 		const action = { payload: mockLevel, type: getLevelById.fulfilled.type };
 		const state = reducer(initialState, action);

--- a/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
+++ b/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { getLevelById } from "~/games/true-false-game/api/slices/true-false-game-actions";
 import { actions, reducer } from "~/games/true-false-game/api/slices/true-false-game.slice";
 import { DataStatus } from "~/libs/enums/enums";
+import { HTTPCode } from "~/libs/modules/http/http";
 import { type TrueFalseGameLevelDto } from "~/games/true-false-game/libs/types/true-false-game-level-dto.type";
 
 describe("true-false-game slice", () => {
@@ -44,9 +45,52 @@ describe("true-false-game slice", () => {
 		expect(state.currentLevel).toEqual(mockLevel);
 	});
 
-	it("should handle getLevelById.rejected", () => {
+	it("should handle getLevelById.rejected with error payload", () => {
+		const errorPayload = { message: "Not Found", status: HTTPCode.NOT_FOUND };
+		const action = { payload: errorPayload, type: getLevelById.rejected.type };
+		const state = reducer(initialState, action);
+
+		expect(state.currentStatus).toEqual(DataStatus.REJECTED);
+		expect(state.error).toEqual(errorPayload);
+	});
+
+	it("should handle getLevelById.rejected without payload", () => {
 		const action = { type: getLevelById.rejected.type };
 		const state = reducer(initialState, action);
+
 		expect(state.currentStatus).toEqual(DataStatus.REJECTED);
+		expect(state.error).toBeNull();
+	});
+
+	it("should clear error on getLevelById.pending", () => {
+		const stateWithError = {
+			...initialState,
+			currentStatus: DataStatus.REJECTED,
+			error: { message: "Not Found", status: HTTPCode.NOT_FOUND },
+		};
+		const action = { type: getLevelById.pending.type };
+		const state = reducer(stateWithError, action);
+
+		expect(state.currentStatus).toEqual(DataStatus.PENDING);
+		expect(state.error).toBeNull();
+	});
+
+	it("should clear error on getLevelById.fulfilled", () => {
+		const mockLevel = {
+			id: 1,
+			statements: [],
+			title: "Level 1",
+		} as unknown as TrueFalseGameLevelDto;
+		const stateWithError = {
+			...initialState,
+			currentStatus: DataStatus.REJECTED,
+			error: { message: "Server Error", status: 500 },
+		};
+		const action = { payload: mockLevel, type: getLevelById.fulfilled.type };
+		const state = reducer(stateWithError, action);
+
+		expect(state.currentStatus).toEqual(DataStatus.FULFILLED);
+		expect(state.currentLevel).toEqual(mockLevel);
+		expect(state.error).toBeNull();
 	});
 });

--- a/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
+++ b/tests/modules/games/true-false-game/true-false-game.slice.spec.ts
@@ -55,11 +55,15 @@ describe("true-false-game slice", () => {
 	});
 
 	it("should handle getLevelById.rejected without payload", () => {
-		const action = { type: getLevelById.rejected.type };
+		const errorMessage = "Internal Server Error";
+		const action = {
+			error: { message: errorMessage },
+			type: getLevelById.rejected.type,
+		};
 		const state = reducer(initialState, action);
 
 		expect(state.currentStatus).toEqual(DataStatus.REJECTED);
-		expect(state.error).toBeNull();
+		expect(state.error).toEqual({ message: errorMessage });
 	});
 
 	it("should clear error on getLevelById.pending", () => {


### PR DESCRIPTION
 - [x] Add an error property to the State type in src/games/true-false-game/api/slices/true-false-game.slice.ts.
 - [x] Update getLevelById.rejected case to populate the error state property.
 - [x] Clear the error state in clearCurrentLevel reducer.
 - [x] Expose error field in the return type of useTrueFalseGame in src/libs/hooks/use-true-false-game/use-true-false-game.hook.ts.
 - [x] Update TrueFalseLevelCard conditional rendering. Return error.notFound if status === REJECTED and the error status code is 404. Otherwise, return error.load for generic errors.