### PR TITLE
Add language switcher to auth layout ss-078

### DIFF
--- a/src/libs/components/components.ts
+++ b/src/libs/components/components.ts
@@ -7,6 +7,7 @@ export { Header } from "./header/header";
 export { Icon } from "./icon/icon";
 export { Input } from "./input/input";
 export { LanguageSwitcher } from "./language-switcher/language-switcher";
+export { LanguageSwitcherVariant } from "./language-switcher/language-switcher-variant.enum";
 export { LevelPreviewCard } from "./level-preview-card/level-preview-card";
 export { Loader } from "./loader/loader";
 export { Logo } from "./logo/logo";

--- a/src/libs/components/header/header.tsx
+++ b/src/libs/components/header/header.tsx
@@ -1,4 +1,9 @@
-import { LanguageSwitcher, Logo, Navigation } from "~/libs/components/components";
+import {
+	LanguageSwitcher,
+	LanguageSwitcherVariant,
+	Logo,
+	Navigation,
+} from "~/libs/components/components";
 import { getValidClassNames } from "~/libs/helpers/helpers";
 
 import styles from "./styles.module.css";
@@ -15,7 +20,7 @@ const Header: React.FC = () => {
 			</div>
 
 			<div className={styles["header__lang"]}>
-				<LanguageSwitcher />
+				<LanguageSwitcher variant={LanguageSwitcherVariant.BASE} />
 			</div>
 		</header>
 	);

--- a/src/libs/components/language-switcher/language-switcher-variant.enum.ts
+++ b/src/libs/components/language-switcher/language-switcher-variant.enum.ts
@@ -1,0 +1,6 @@
+const LanguageSwitcherVariant = {
+	AUTH: "language-switcher--auth",
+	BASE: "language-switcher--base",
+} as const;
+
+export { LanguageSwitcherVariant };

--- a/src/libs/components/language-switcher/language-switcher.tsx
+++ b/src/libs/components/language-switcher/language-switcher.tsx
@@ -1,13 +1,21 @@
+import { getValidClassNames } from "~/libs/helpers/helpers";
 import { useCallback, useMemo, useTranslation } from "~/libs/hooks/hooks";
 import {
 	type Language,
 	LANGUAGE_TO_LABEL,
 	useLanguageSwitcher,
 } from "~/libs/modules/localization/localization";
+import { type ValueOf } from "~/libs/types/types";
 
 import { Dropdown } from "../components";
+import { type LanguageSwitcherVariant } from "./language-switcher-variant.enum";
+import styles from "./styles.module.css";
 
-const LanguageSwitcher: React.FC = () => {
+type Properties = {
+	variant: ValueOf<typeof LanguageSwitcherVariant>;
+};
+
+const LanguageSwitcher: React.FC<Properties> = ({ variant }) => {
 	const { t } = useTranslation();
 	const { availableLanguages, changeLanguage, currentLanguage } = useLanguageSwitcher();
 
@@ -29,6 +37,7 @@ const LanguageSwitcher: React.FC = () => {
 
 	return (
 		<Dropdown
+			className={getValidClassNames(styles[variant])}
 			onSelect={handleLanguageChange}
 			options={options}
 			toggleAriaLabel={t("common.localization.selectLanguage")}

--- a/src/libs/components/language-switcher/styles.module.css
+++ b/src/libs/components/language-switcher/styles.module.css
@@ -1,0 +1,7 @@
+.language-switcher--base > button {
+	color: var(--color-brand);
+}
+
+.language-switcher--auth > button {
+	color: var(--color-text-primary);
+}

--- a/src/libs/modules/localization/enums/language.enum.ts
+++ b/src/libs/modules/localization/enums/language.enum.ts
@@ -1,5 +1,9 @@
-export enum Language {
+enum Language {
 	EN = "en",
 	ES = "es",
 	UK = "uk",
 }
+
+const AVAILABLE_LANGUAGES = Object.values(Language);
+
+export { AVAILABLE_LANGUAGES, Language };

--- a/src/libs/modules/localization/hooks/use-language-switcher.ts
+++ b/src/libs/modules/localization/hooks/use-language-switcher.ts
@@ -1,6 +1,6 @@
 import { useTranslation } from "~/libs/hooks/hooks";
 
-import { Language } from "../enums/language.enum";
+import { AVAILABLE_LANGUAGES, Language } from "../enums/language.enum";
 import { type LanguageSwitcher } from "../types/localization.types";
 
 const useLanguageSwitcher = (): LanguageSwitcher => {
@@ -10,10 +10,10 @@ const useLanguageSwitcher = (): LanguageSwitcher => {
 		await i18n.changeLanguage(language);
 	};
 
-	const isSupportedLanguage = Object.values(Language).includes(i18n.language as Language);
+	const isSupportedLanguage = AVAILABLE_LANGUAGES.includes(i18n.language as Language);
 
 	return {
-		availableLanguages: Object.values(Language),
+		availableLanguages: AVAILABLE_LANGUAGES,
 		changeLanguage,
 		currentLanguage: isSupportedLanguage ? (i18n.language as Language) : Language.EN,
 	};

--- a/src/modules/auth/components/auth-layout/auth-layout.tsx
+++ b/src/modules/auth/components/auth-layout/auth-layout.tsx
@@ -1,4 +1,4 @@
-import { LanguageSwitcher, Link } from "~/libs/components/components";
+import { LanguageSwitcher, LanguageSwitcherVariant, Link } from "~/libs/components/components";
 import { getValidClassNames } from "~/libs/helpers/helpers";
 
 import styles from "./styles.module.css";
@@ -25,7 +25,7 @@ const AuthLayout: React.FC<AuthLayoutProperties> = ({
 			<div className={getValidClassNames(styles["auth-page__container"])}>
 				<div className={getValidClassNames(styles["auth-page__card"])}>
 					<div className={getValidClassNames(styles["auth-page__lang-switcher"])}>
-						<LanguageSwitcher />
+						<LanguageSwitcher variant={LanguageSwitcherVariant.AUTH} />
 					</div>
 					<h1 className={getValidClassNames(styles["auth-page__title"])}>{title}</h1>
 					<p className={getValidClassNames(styles["auth-page__subtitle"])}>{subtitle}</p>

--- a/src/modules/auth/components/auth-layout/auth-layout.tsx
+++ b/src/modules/auth/components/auth-layout/auth-layout.tsx
@@ -1,4 +1,4 @@
-import { Link } from "~/libs/components/components";
+import { LanguageSwitcher, Link } from "~/libs/components/components";
 import { getValidClassNames } from "~/libs/helpers/helpers";
 
 import styles from "./styles.module.css";
@@ -24,6 +24,9 @@ const AuthLayout: React.FC<AuthLayoutProperties> = ({
 		<div className={getValidClassNames(styles["auth-page"])}>
 			<div className={getValidClassNames(styles["auth-page__container"])}>
 				<div className={getValidClassNames(styles["auth-page__card"])}>
+					<div className={getValidClassNames(styles["auth-page__lang-switcher"])}>
+						<LanguageSwitcher />
+					</div>
 					<h1 className={getValidClassNames(styles["auth-page__title"])}>{title}</h1>
 					<p className={getValidClassNames(styles["auth-page__subtitle"])}>{subtitle}</p>
 

--- a/src/modules/auth/components/auth-layout/styles.module.css
+++ b/src/modules/auth/components/auth-layout/styles.module.css
@@ -73,3 +73,9 @@
 		font-size: 1.75rem;
 	}
 }
+
+.auth-page__lang-switcher {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 1.25rem;
+}

--- a/src/pages/auth-google-callback-page/auth-google-callback-page.tsx
+++ b/src/pages/auth-google-callback-page/auth-google-callback-page.tsx
@@ -1,11 +1,5 @@
 import { AppRoute } from "~/libs/enums/enums";
-import {
-	useAppDispatch,
-	useEffect,
-	useNavigate,
-	useRef,
-	useTranslation,
-} from "~/libs/hooks/hooks";
+import { useAppDispatch, useEffect, useNavigate, useRef, useTranslation } from "~/libs/hooks/hooks";
 import { loginWithGoogle } from "~/modules/auth/auth";
 
 const GOOGLE_ERROR_I18N_KEYS: Record<string, string> = {


### PR DESCRIPTION
 - [x] Import LanguageSwitcher from ~/libs/components/components in AuthLayout
 - [x] Render LanguageSwitcher inside a wrapper div above the page title in AuthLayout
 - [x] Add .auth-page__lang-switcher CSS rule with right-aligned flex layout in styles.module.css