### PR TITLE
feat(admin); create admin bootstrap ss-089

### DIFF
--- a/src/libs/components/guest-route/guest-route.tsx
+++ b/src/libs/components/guest-route/guest-route.tsx
@@ -4,7 +4,7 @@ import { AppRoute } from "~/libs/enums/enums";
 import { useAppSelector } from "~/libs/hooks/hooks";
 
 const GuestRoute: React.FC = () => {
-	const { isAuthenticated } = useAppSelector(({ auth }) => auth);
+	const isAuthenticated = useAppSelector(({ auth }) => auth.isAuthenticated);
 
 	if (isAuthenticated) {
 		return <Navigate replace to={AppRoute.PROFILE} />;

--- a/src/libs/components/navigation/navigation.tsx
+++ b/src/libs/components/navigation/navigation.tsx
@@ -19,7 +19,7 @@ const LOGOUT_OPTION = "logout";
 
 const Navigation: React.FC = () => {
 	const { t } = useTranslation();
-	const { isAuthenticated } = useAppSelector((state) => state.auth);
+	const isAuthenticated = useAppSelector((state) => state.auth.isAuthenticated);
 	const { logout } = useLogout();
 	const navigate = useNavigate();
 	const { pathname } = useLocation();

--- a/src/libs/components/protected-route/protected-route.tsx
+++ b/src/libs/components/protected-route/protected-route.tsx
@@ -4,7 +4,7 @@ import { AppRoute } from "~/libs/enums/enums";
 import { useAppSelector } from "~/libs/hooks/hooks";
 
 const ProtectedRoute: React.FC = () => {
-	const { isAuthenticated } = useAppSelector(({ auth }) => auth);
+	const isAuthenticated = useAppSelector(({ auth }) => auth.isAuthenticated);
 
 	if (!isAuthenticated) {
 		return <Navigate replace to={AppRoute.LOGIN} />;

--- a/src/libs/components/router-provider/router-provider.tsx
+++ b/src/libs/components/router-provider/router-provider.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter } from "react-router-dom";
 import { App } from "~/app";
 import { MainLayout } from "~/libs/components/components";
 import { AppRoute } from "~/libs/enums/enums";
+import { AdminLayout, RequireAdmin } from "~/modules/admin/admin";
 import { LevelContentPage } from "~/pages/level-content-page/level-content-page";
 import {
 	AuthGoogleCallbackPage,
@@ -37,6 +38,24 @@ export const router = createBrowserRouter([
 					},
 				],
 				element: <MainLayout />,
+			},
+			{
+				children: [
+					{
+						children: [
+							{
+								children: [
+									// Child routes (ADMIN_GAME_LEVELS, ADMIN_GAME_LEVEL_EDITOR) are
+									// populated by WIW-FE-01; they use absolute paths under /admin.
+								],
+								element: <AdminLayout />,
+								path: AppRoute.ADMIN_ROOT,
+							},
+						],
+						element: <RequireAdmin />,
+					},
+				],
+				element: <ProtectedRoute />,
 			},
 		],
 		element: <App />,

--- a/src/libs/enums/app-route.enum.ts
+++ b/src/libs/enums/app-route.enum.ts
@@ -1,4 +1,7 @@
 const AppRoute = {
+	ADMIN_GAME_LEVEL_EDITOR: "/admin/games/:gameId/levels/:levelId",
+	ADMIN_GAME_LEVELS: "/admin/games/:gameId/levels",
+	ADMIN_ROOT: "/admin",
 	AUTH_GOOGLE_CALLBACK: "/auth/google/callback",
 	GAME_CONTENT: "/games/:id",
 	GAMES: "/games",

--- a/src/libs/modules/localization/locales/en/admin.ts
+++ b/src/libs/modules/localization/locales/en/admin.ts
@@ -1,0 +1,8 @@
+const admin = {
+	header: {
+		loggedInAs: "Logged in as {{name}}",
+		title: "Admin",
+	},
+};
+
+export { admin };

--- a/src/libs/modules/localization/locales/en/index.ts
+++ b/src/libs/modules/localization/locales/en/index.ts
@@ -1,3 +1,4 @@
+import { admin } from "./admin";
 import { auth } from "./auth";
 import { common } from "./common";
 import { games } from "./games";
@@ -6,6 +7,7 @@ import { profile } from "./profile";
 import { validation } from "./validation";
 
 export const en = {
+	admin,
 	auth,
 	common,
 	games,

--- a/src/libs/modules/localization/locales/es/admin.ts
+++ b/src/libs/modules/localization/locales/es/admin.ts
@@ -1,0 +1,8 @@
+const admin = {
+	header: {
+		loggedInAs: "Conectado como {{name}}",
+		title: "Administración",
+	},
+};
+
+export { admin };

--- a/src/libs/modules/localization/locales/es/index.ts
+++ b/src/libs/modules/localization/locales/es/index.ts
@@ -1,3 +1,4 @@
+import { admin } from "./admin";
 import { auth } from "./auth";
 import { common } from "./common";
 import { games } from "./games";
@@ -6,6 +7,7 @@ import { profile } from "./profile";
 import { validation } from "./validation";
 
 export const es = {
+	admin,
 	auth,
 	common,
 	games,

--- a/src/libs/modules/localization/locales/uk/admin.ts
+++ b/src/libs/modules/localization/locales/uk/admin.ts
@@ -1,0 +1,8 @@
+const admin = {
+	header: {
+		loggedInAs: "Ви увійшли як {{name}}",
+		title: "Адміністрування",
+	},
+};
+
+export { admin };

--- a/src/libs/modules/localization/locales/uk/index.ts
+++ b/src/libs/modules/localization/locales/uk/index.ts
@@ -1,3 +1,4 @@
+import { admin } from "./admin";
 import { auth } from "./auth";
 import { common } from "./common";
 import { games } from "./games";
@@ -6,6 +7,7 @@ import { profile } from "./profile";
 import { validation } from "./validation";
 
 export const uk = {
+	admin,
 	auth,
 	common,
 	games,

--- a/src/modules/admin/admin.ts
+++ b/src/modules/admin/admin.ts
@@ -1,0 +1,1 @@
+export { AdminLayout, RequireAdmin, SidebarNav } from "./components/components";

--- a/src/modules/admin/admin.ts
+++ b/src/modules/admin/admin.ts
@@ -1,1 +1,1 @@
-export { AdminLayout, RequireAdmin, SidebarNav } from "./components/components";
+export { AdminLayout, RequireAdmin } from "./components/components";

--- a/src/modules/admin/components/admin-layout/admin-layout.tsx
+++ b/src/modules/admin/components/admin-layout/admin-layout.tsx
@@ -1,0 +1,53 @@
+import { Outlet } from "react-router-dom";
+
+import {
+	Button,
+	LanguageSwitcher,
+	LanguageSwitcherVariant,
+	Logo,
+} from "~/libs/components/components";
+import { useAppSelector, useCallback, useTranslation } from "~/libs/hooks/hooks";
+import { useLogout } from "~/modules/auth/auth";
+
+import { SidebarNav } from "../sidebar-nav/sidebar-nav";
+import styles from "./styles.module.css";
+
+const AdminLayout: React.FC = () => {
+	const { t } = useTranslation();
+	const { logout } = useLogout();
+	const user = useAppSelector(({ auth }) => auth.user);
+
+	const handleLogout = useCallback((): void => {
+		void logout();
+	}, [logout]);
+
+	return (
+		<div className={styles["admin-layout"]}>
+			<header className={styles["admin-layout__header"]}>
+				<div className={styles["admin-layout__brand"]}>
+					<Logo />
+					<h1 className={styles["admin-layout__title"]}>{t("admin.header.title")}</h1>
+				</div>
+				<div className={styles["admin-layout__actions"]}>
+					{user && (
+						<span className={styles["admin-layout__user"]}>
+							{t("admin.header.loggedInAs", { name: user.name })}
+						</span>
+					)}
+					<LanguageSwitcher variant={LanguageSwitcherVariant.BASE} />
+					<Button onClick={handleLogout} variant="secondary">
+						{t("common.navigation.logout")}
+					</Button>
+				</div>
+			</header>
+			<div className={styles["admin-layout__body"]}>
+				<SidebarNav />
+				<main className={styles["admin-layout__main"]}>
+					<Outlet />
+				</main>
+			</div>
+		</div>
+	);
+};
+
+export { AdminLayout };

--- a/src/modules/admin/components/admin-layout/styles.module.css
+++ b/src/modules/admin/components/admin-layout/styles.module.css
@@ -1,7 +1,8 @@
 .admin-layout {
 	display: flex;
 	flex-direction: column;
-	min-height: 100vh;
+	height: 100dvh;
+	overflow: hidden;
 	font-family: var(--font-family);
 	color: var(--color-text-1);
 	background-color: var(--color-background-2);
@@ -9,6 +10,7 @@
 
 .admin-layout__header {
 	display: flex;
+	flex-shrink: 0;
 	gap: var(--spacing-sm);
 	align-items: center;
 	justify-content: space-between;
@@ -49,6 +51,7 @@
 	display: flex;
 	flex: 1 1 auto;
 	min-height: 0;
+	overflow: hidden;
 }
 
 .admin-layout__main {

--- a/src/modules/admin/components/admin-layout/styles.module.css
+++ b/src/modules/admin/components/admin-layout/styles.module.css
@@ -1,0 +1,59 @@
+.admin-layout {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+	font-family: var(--font-family);
+	color: var(--color-text-1);
+	background-color: var(--color-background-2);
+}
+
+.admin-layout__header {
+	display: flex;
+	gap: var(--spacing-sm);
+	align-items: center;
+	justify-content: space-between;
+	min-height: var(--header-height-md);
+	padding: var(--spacing-xs) var(--spacing-md);
+	color: var(--color-text-light);
+	background-color: var(--color-background-dark);
+	border-bottom: 1px solid var(--color-dark-border-subtle);
+	box-shadow: var(--shadow-sm);
+}
+
+.admin-layout__brand {
+	display: flex;
+	gap: var(--spacing-xs);
+	align-items: center;
+}
+
+.admin-layout__title {
+	margin: 0;
+	font-size: var(--font-size-base);
+	font-weight: var(--font-weight-semibold);
+	color: var(--color-text-light);
+}
+
+.admin-layout__actions {
+	display: flex;
+	gap: var(--spacing-sm);
+	align-items: center;
+}
+
+.admin-layout__user {
+	font-size: var(--font-size-xs);
+	font-weight: var(--font-weight-medium);
+	color: var(--color-text-light);
+}
+
+.admin-layout__body {
+	display: flex;
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+.admin-layout__main {
+	flex: 1 1 auto;
+	padding: var(--spacing-md);
+	overflow: auto;
+	background-color: var(--color-background-4);
+}

--- a/src/modules/admin/components/components.ts
+++ b/src/modules/admin/components/components.ts
@@ -1,0 +1,3 @@
+export { AdminLayout } from "./admin-layout/admin-layout";
+export { RequireAdmin } from "./require-admin/require-admin";
+export { SidebarNav } from "./sidebar-nav/sidebar-nav";

--- a/src/modules/admin/components/components.ts
+++ b/src/modules/admin/components/components.ts
@@ -1,3 +1,2 @@
 export { AdminLayout } from "./admin-layout/admin-layout";
 export { RequireAdmin } from "./require-admin/require-admin";
-export { SidebarNav } from "./sidebar-nav/sidebar-nav";

--- a/src/modules/admin/components/require-admin/require-admin.tsx
+++ b/src/modules/admin/components/require-admin/require-admin.tsx
@@ -1,0 +1,16 @@
+import { Navigate, Outlet } from "react-router-dom";
+
+import { AppRoute } from "~/libs/enums/enums";
+import { useAppSelector } from "~/libs/hooks/hooks";
+
+const RequireAdmin: React.FC = () => {
+	const user = useAppSelector(({ auth }) => auth.user);
+
+	if (!user || !user.is_admin) {
+		return <Navigate replace to={AppRoute.ROOT} />;
+	}
+
+	return <Outlet />;
+};
+
+export { RequireAdmin };

--- a/src/modules/admin/components/sidebar-nav/sidebar-nav.tsx
+++ b/src/modules/admin/components/sidebar-nav/sidebar-nav.tsx
@@ -1,0 +1,7 @@
+import styles from "./styles.module.css";
+
+const SidebarNav: React.FC = () => {
+	return <nav className={styles["sidebar-nav"]} />;
+};
+
+export { SidebarNav };

--- a/src/modules/admin/components/sidebar-nav/styles.module.css
+++ b/src/modules/admin/components/sidebar-nav/styles.module.css
@@ -1,10 +1,11 @@
 .sidebar-nav {
 	display: flex;
+	flex-shrink: 0;
 	flex-direction: column;
 	gap: var(--spacing-xs);
 	width: 16rem;
-	min-height: 100%;
 	padding: var(--spacing-sm);
+	overflow-y: auto;
 	font-family: var(--font-family);
 	color: var(--color-text-1);
 	background-color: var(--color-background-light-gray);

--- a/src/modules/admin/components/sidebar-nav/styles.module.css
+++ b/src/modules/admin/components/sidebar-nav/styles.module.css
@@ -1,0 +1,12 @@
+.sidebar-nav {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+	width: 16rem;
+	min-height: 100%;
+	padding: var(--spacing-sm);
+	font-family: var(--font-family);
+	color: var(--color-text-1);
+	background-color: var(--color-background-light-gray);
+	border-right: 1px solid var(--color-dark-border-subtle);
+}

--- a/src/modules/auth/auth.api.ts
+++ b/src/modules/auth/auth.api.ts
@@ -33,7 +33,9 @@ class AuthApi extends BaseHTTPApi {
 			payload: null,
 		});
 
-		return await response.json<User>();
+		const data = await response.json<{ user: User }>();
+
+		return data.user;
 	}
 
 	public async getGoogleRedirectUrl(): Promise<{ url: string }> {

--- a/src/modules/auth/libs/types/user.type.ts
+++ b/src/modules/auth/libs/types/user.type.ts
@@ -1,6 +1,7 @@
 type User = {
 	email: string;
 	id: number;
+	is_admin: boolean;
 	name: string;
 };
 

--- a/src/pages/home-page/home-page.tsx
+++ b/src/pages/home-page/home-page.tsx
@@ -8,7 +8,7 @@ import styles from "./styles.module.css";
 
 const HomePage: React.FC = () => {
 	const { t } = useTranslation();
-	const { isAuthenticated } = useAppSelector(({ auth }) => auth);
+	const isAuthenticated = useAppSelector(({ auth }) => auth.isAuthenticated);
 
 	return (
 		<div className={styles["home-page"]}>

--- a/tests/libs/components/guest-route/guest-route.spec.tsx
+++ b/tests/libs/components/guest-route/guest-route.spec.tsx
@@ -14,7 +14,7 @@ type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
 	error: null | { message: string };
 	isAuthenticated: boolean;
-	user: null | { email: string; id: number; name: string };
+	user: null | { email: string; id: number; is_admin: boolean; name: string };
 };
 
 const createMockStore = (initialAuthState?: Partial<AuthState>): ReturnType<typeof configureStore> => {

--- a/tests/libs/components/navigation/navigation.spec.tsx
+++ b/tests/libs/components/navigation/navigation.spec.tsx
@@ -16,7 +16,7 @@ type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
 	error: null | { message: string };
 	isAuthenticated: boolean;
-	user: null | { email: string; id: number; name: string };
+	user: null | { email: string; id: number; is_admin: boolean; name: string };
 };
 
 const mockLogout = vi.fn();

--- a/tests/libs/components/protected-route/protected-route.spec.tsx
+++ b/tests/libs/components/protected-route/protected-route.spec.tsx
@@ -14,7 +14,7 @@ type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
 	error: null | { message: string };
 	isAuthenticated: boolean;
-	user: null | { email: string; id: number; name: string };
+	user: null | { email: string; id: number; is_admin: boolean; name: string };
 };
 
 const createMockStore = (initialAuthState?: Partial<AuthState>): ReturnType<typeof configureStore> => {

--- a/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
+++ b/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { configureStore } from "@reduxjs/toolkit";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { DataStatus } from "~/libs/enums/enums";
+import { AdminLayout } from "~/modules/admin/components/admin-layout/admin-layout";
+import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
+
+const createMockStore = (): ReturnType<typeof configureStore> => {
+	return configureStore({
+		preloadedState: {
+			auth: {
+				dataStatus: DataStatus.IDLE,
+				error: null,
+				isAuthenticated: true,
+				user: { email: "a@a.com", id: 1, is_admin: true, name: "Admin" },
+			},
+		},
+		reducer: {
+			auth: authReducer,
+		},
+	});
+};
+
+describe("AdminLayout", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders the outlet content for a child route", () => {
+		const store = createMockStore();
+
+		render(
+			<Provider store={store}>
+				<MemoryRouter initialEntries={["/admin"]}>
+					<Routes>
+						<Route element={<AdminLayout />} path="/admin">
+							<Route element={<div>Admin Inner</div>} index />
+						</Route>
+					</Routes>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(screen.getByText("Admin Inner")).toBeInTheDocument();
+	});
+
+	it("renders a logout control in the header", () => {
+		const store = createMockStore();
+
+		render(
+			<Provider store={store}>
+				<MemoryRouter initialEntries={["/admin"]}>
+					<Routes>
+						<Route element={<AdminLayout />} path="/admin">
+							<Route element={<div />} index />
+						</Route>
+					</Routes>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const buttons = screen.getAllByRole("button");
+
+		expect(buttons.length).toBeGreaterThan(0);
+	});
+});

--- a/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
+++ b/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
@@ -1,17 +1,32 @@
 // @vitest-environment jsdom
 import { configureStore } from "@reduxjs/toolkit";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 
+import type * as authModule from "~/modules/auth/auth";
+
 import { DataStatus } from "~/libs/enums/enums";
+import { i18n } from "~/libs/modules/localization/i18n";
 import { AdminLayout } from "~/modules/admin/components/admin-layout/admin-layout";
 import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
 
-const createMockStore = (): ReturnType<typeof configureStore> => {
-	return configureStore({
+const mockLogout = vi.fn();
+
+vi.mock("~/modules/auth/auth", async (importOriginal) => {
+	const actual = await importOriginal<typeof authModule>();
+
+	return {
+		...actual,
+		useLogout: (): { logout: typeof mockLogout } => ({ logout: mockLogout }),
+	};
+});
+
+const renderAdminLayout = (): ReturnType<typeof render> => {
+	const store = configureStore({
 		preloadedState: {
 			auth: {
 				dataStatus: DataStatus.IDLE,
@@ -24,48 +39,44 @@ const createMockStore = (): ReturnType<typeof configureStore> => {
 			auth: authReducer,
 		},
 	});
+
+	return render(
+		<Provider store={store}>
+			<MemoryRouter initialEntries={["/admin"]}>
+				<Routes>
+					<Route element={<AdminLayout />} path="/admin">
+						<Route element={<div>Admin Inner</div>} index />
+					</Route>
+				</Routes>
+			</MemoryRouter>
+		</Provider>
+	);
 };
 
 describe("AdminLayout", () => {
+	beforeEach(() => {
+		mockLogout.mockClear();
+	});
+
 	afterEach(() => {
 		cleanup();
 	});
 
 	it("renders the outlet content for a child route", () => {
-		const store = createMockStore();
-
-		render(
-			<Provider store={store}>
-				<MemoryRouter initialEntries={["/admin"]}>
-					<Routes>
-						<Route element={<AdminLayout />} path="/admin">
-							<Route element={<div>Admin Inner</div>} index />
-						</Route>
-					</Routes>
-				</MemoryRouter>
-			</Provider>
-		);
+		renderAdminLayout();
 
 		expect(screen.getByText("Admin Inner")).toBeInTheDocument();
 	});
 
-	it("renders a logout control in the header", () => {
-		const store = createMockStore();
+	it("invokes logout when the header logout button is clicked", async () => {
+		renderAdminLayout();
 
-		render(
-			<Provider store={store}>
-				<MemoryRouter initialEntries={["/admin"]}>
-					<Routes>
-						<Route element={<AdminLayout />} path="/admin">
-							<Route element={<div />} index />
-						</Route>
-					</Routes>
-				</MemoryRouter>
-			</Provider>
-		);
+		const logoutButton = screen.getByRole("button", {
+			name: i18n.t("common.navigation.logout"),
+		});
 
-		const buttons = screen.getAllByRole("button");
+		await userEvent.click(logoutButton);
 
-		expect(buttons.length).toBeGreaterThan(0);
+		expect(mockLogout).toHaveBeenCalledTimes(1);
 	});
 });

--- a/tests/modules/admin/components/require-admin/require-admin.spec.tsx
+++ b/tests/modules/admin/components/require-admin/require-admin.spec.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { configureStore } from "@reduxjs/toolkit";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { DataStatus } from "~/libs/enums/enums";
+import { RequireAdmin } from "~/modules/admin/components/require-admin/require-admin";
+import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
+
+type AuthState = {
+	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
+	error: null | { message: string };
+	isAuthenticated: boolean;
+	user: MockUser | null;
+};
+
+type MockUser = { email: string; id: number; is_admin: boolean; name: string };
+
+const ADMIN_USER: MockUser = { email: "a@a.com", id: 1, is_admin: true, name: "Admin" };
+const REGULAR_USER: MockUser = { email: "u@u.com", id: 2, is_admin: false, name: "User" };
+
+const createMockStore = (
+	initialAuthState?: Partial<AuthState>
+): ReturnType<typeof configureStore> => {
+	return configureStore({
+		preloadedState: {
+			auth: {
+				dataStatus: DataStatus.IDLE,
+				error: null,
+				isAuthenticated: false,
+				user: null,
+				...initialAuthState,
+			},
+		},
+		reducer: {
+			auth: authReducer,
+		},
+	});
+};
+
+const renderWithProvider = (
+	initialAuthState?: Partial<AuthState>,
+	initialEntries = ["/admin"]
+): ReturnType<typeof render> => {
+	const store = createMockStore(initialAuthState);
+
+	return render(
+		<Provider store={store}>
+			<MemoryRouter initialEntries={initialEntries}>
+				<Routes>
+					<Route element={<RequireAdmin />}>
+						<Route element={<div>Admin Content</div>} path="/admin" />
+					</Route>
+					<Route element={<div>Home Page</div>} path="/" />
+				</Routes>
+			</MemoryRouter>
+		</Provider>
+	);
+};
+
+describe("RequireAdmin", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders Outlet when user is admin", () => {
+		renderWithProvider({ isAuthenticated: true, user: ADMIN_USER });
+
+		expect(screen.getByText("Admin Content")).toBeInTheDocument();
+		expect(screen.queryByText("Home Page")).not.toBeInTheDocument();
+	});
+
+	it("redirects to / when user is authenticated but not admin", () => {
+		renderWithProvider({ isAuthenticated: true, user: REGULAR_USER });
+
+		expect(screen.getByText("Home Page")).toBeInTheDocument();
+		expect(screen.queryByText("Admin Content")).not.toBeInTheDocument();
+	});
+
+	it("redirects to / when there is no user at all", () => {
+		renderWithProvider({ isAuthenticated: false, user: null });
+
+		expect(screen.getByText("Home Page")).toBeInTheDocument();
+		expect(screen.queryByText("Admin Content")).not.toBeInTheDocument();
+	});
+});

--- a/tests/modules/auth/auth.api.spec.ts
+++ b/tests/modules/auth/auth.api.spec.ts
@@ -64,6 +64,7 @@ describe("AuthApi.register", () => {
 			user: {
 				email: "test@example.com",
 				id: 1,
+				is_admin: false,
 				name: "Test User",
 			},
 		};
@@ -136,6 +137,7 @@ describe("AuthApi.login", () => {
 			user: {
 				email: "test@example.com",
 				id: 1,
+				is_admin: false,
 				name: "Test User",
 			},
 		};
@@ -196,11 +198,13 @@ describe("AuthApi.getAuthenticatedUser", () => {
 	});
 
 	it("sends correct request and returns user on success", async () => {
-		const responseData: User = {
+		const expectedUser: User = {
 			email: "test@example.com",
 			id: 1,
+			is_admin: false,
 			name: "Test User",
 		};
+		const responseData = { user: expectedUser };
 		const token = "some-token";
 
 		http.load.mockResolvedValueOnce(makeResponse(responseData));
@@ -227,7 +231,7 @@ describe("AuthApi.getAuthenticatedUser", () => {
 		const [, options] = http.load.mock.calls[0] as HttpCallArguments;
 		expect(options.headers.get("authorization")).toBe(`Bearer ${token}`);
 
-		expect(result).toEqual(responseData);
+		expect(result).toEqual(expectedUser);
 	});
 
 	it("propagates error when request fails", async () => {

--- a/tests/modules/auth/auth.slice.spec.ts
+++ b/tests/modules/auth/auth.slice.spec.ts
@@ -39,7 +39,7 @@ describe("auth slice", () => {
 		});
 
 		it("handles login.fulfilled action", () => {
-			const mockUser = { email: "test@example.com", id: 1, name: "Test User" };
+			const mockUser = { email: "test@example.com", id: 1, is_admin: false, name: "Test User" };
 			const action = {
 				payload: { access_token: "fake-token", user: mockUser },
 				type: login.fulfilled.type,
@@ -84,7 +84,7 @@ describe("auth slice", () => {
 		});
 
 		it("handles getAuthenticatedUser.fulfilled action", () => {
-			const mockUser = { email: "test@example.com", id: 1, name: "Test User" };
+			const mockUser = { email: "test@example.com", id: 1, is_admin: false, name: "Test User" };
 			const action = {
 				payload: mockUser,
 				type: getAuthenticatedUser.fulfilled.type,
@@ -101,7 +101,7 @@ describe("auth slice", () => {
 			const stateWithUser = {
 				...initialState,
 				isAuthenticated: true,
-				user: { email: "test@example.com", id: 1, name: "Test User" },
+				user: { email: "test@example.com", id: 1, is_admin: false, name: "Test User" },
 			};
 			const action = { type: getAuthenticatedUser.rejected.type };
 			const state = reducer(stateWithUser, action);
@@ -121,7 +121,7 @@ describe("auth slice", () => {
 		});
 
 		it("handles register.fulfilled action", () => {
-			const mockUser = { email: "test@example.com", id: 1, name: "Test User" };
+			const mockUser = { email: "test@example.com", id: 1, is_admin: false, name: "Test User" };
 			const action = {
 				payload: { access_token: "fake-token", user: mockUser },
 				type: register.fulfilled.type,
@@ -166,7 +166,7 @@ describe("auth slice", () => {
 		});
 
 		it("handles loginWithGoogle.fulfilled action", () => {
-			const mockUser = { email: "test@example.com", id: 1, name: "Test User" };
+			const mockUser = { email: "test@example.com", id: 1, is_admin: false, name: "Test User" };
 			const action = { payload: mockUser, type: loginWithGoogle.fulfilled.type };
 			const state = reducer(initialState, action);
 
@@ -217,7 +217,7 @@ describe("auth slice", () => {
 				dataStatus: DataStatus.FULFILLED,
 				error: { message: "Some error" },
 				isAuthenticated: true,
-				user: { email: "test@example.com", id: 1, name: "Test User" },
+				user: { email: "test@example.com", id: 1, is_admin: false, name: "Test User" },
 			};
 			const action = { type: logout.fulfilled.type };
 			const state = reducer(authenticatedState, action);
@@ -241,7 +241,7 @@ describe("auth slice", () => {
 				dataStatus: DataStatus.FULFILLED,
 				error: { message: "Some error" },
 				isAuthenticated: true,
-				user: { email: "test@example.com", id: 1, name: "Test User" },
+				user: { email: "test@example.com", id: 1, is_admin: false, name: "Test User" },
 			};
 			const action = { type: logout.rejected.type };
 			const state = reducer(authenticatedState, action);
@@ -257,7 +257,7 @@ describe("auth slice", () => {
 		it("calls authApi.register and stores token in storage on success", async () => {
 			const mockResponse = {
 				access_token: "fake-token",
-				user: { email: "test@example.com", id: 1, name: "Test User" },
+				user: { email: "test@example.com", id: 1, is_admin: false, name: "Test User" },
 			};
 			const authApiMock = { register: vi.fn().mockResolvedValue(mockResponse) };
 			const storageMock = { set: vi.fn<() => Promise<void>>().mockResolvedValue() };
@@ -301,7 +301,7 @@ describe("auth slice", () => {
 
 	describe("getAuthenticatedUser thunk", () => {
 		it("calls authApi.getAuthenticatedUser on success", async () => {
-			const mockUser = { email: "test@example.com", id: 1, name: "Test User" };
+			const mockUser = { email: "test@example.com", id: 1, is_admin: false, name: "Test User" };
 			const authApiMock = { getAuthenticatedUser: vi.fn().mockResolvedValue(mockUser) };
 			const storageMock = { drop: vi.fn(), has: vi.fn().mockResolvedValue(true), set: vi.fn() };
 			const extra = { authApi: authApiMock, storage: storageMock } as unknown as ThunkExtra;
@@ -388,7 +388,7 @@ describe("auth slice", () => {
 
 	describe("loginWithGoogle thunk", () => {
 		it("stores token and returns authenticated user on success", async () => {
-			const mockUser = { email: "test@example.com", id: 1, name: "Test User" };
+			const mockUser = { email: "test@example.com", id: 1, is_admin: false, name: "Test User" };
 			const token = "google-access-token";
 			const authApiMock = { getAuthenticatedUser: vi.fn().mockResolvedValue(mockUser) };
 			const storageMock = {
@@ -477,7 +477,7 @@ describe("auth slice", () => {
 		it("calls authApi.login and stores token in storage on success", async () => {
 			const mockResponse = {
 				access_token: "fake-token",
-				user: { email: "test@example.com", id: 1, name: "Test User" },
+				user: { email: "test@example.com", id: 1, is_admin: false, name: "Test User" },
 			};
 			const authApiMock = { login: vi.fn().mockResolvedValue(mockResponse) };
 			const storageMock = { set: vi.fn<() => Promise<void>>().mockResolvedValue() };

--- a/tests/modules/auth/components/register-form/register-form.spec.tsx
+++ b/tests/modules/auth/components/register-form/register-form.spec.tsx
@@ -17,7 +17,7 @@ type AuthState = {
 	dataStatus: (typeof DataStatus)[keyof typeof DataStatus];
 	error: null | { message: string };
 	isAuthenticated: boolean;
-	user: null | { email: string; id: number; name: string };
+	user: null | { email: string; id: number; is_admin: boolean; name: string };
 };
 
 const REQUIRED_FIELD_COUNT = 4;


### PR DESCRIPTION
 - [x] Extend src/modules/auth/libs/types/user.type.ts: add is_admin: boolean
 - [x] Add to src/libs/enums/app-route.enum.ts generic admin routes
 - [x] Create AdminLayout
 - [x] In src/libs/components/router-provider/router-provider.tsx, add a sibling route group to the existing ProtectedRoute block
 - [x] Add tests in src/modules/admin/components/require-admin/require-admin.test.tsx