### PR TITLE
feat(admin): add generic admin level pages ss-091

### DIFF
--- a/src/libs/components/router-provider/router-provider.tsx
+++ b/src/libs/components/router-provider/router-provider.tsx
@@ -6,6 +6,9 @@ import { AppRoute } from "~/libs/enums/enums";
 import { AdminLayout, RequireAdmin } from "~/modules/admin/admin";
 import { LevelContentPage } from "~/pages/level-content-page/level-content-page";
 import {
+	AdminLevelEditorPage,
+	AdminLevelsListPage,
+	AdminWelcomePage,
 	AuthGoogleCallbackPage,
 	GameContentPage,
 	GameSelectionPage,
@@ -45,8 +48,15 @@ export const router = createBrowserRouter([
 						children: [
 							{
 								children: [
-									// Child routes (ADMIN_GAME_LEVELS, ADMIN_GAME_LEVEL_EDITOR) are
-									// populated by WIW-FE-01; they use absolute paths under /admin.
+									{ element: <AdminWelcomePage />, index: true },
+									{
+										element: <AdminLevelsListPage />,
+										path: AppRoute.ADMIN_GAME_LEVELS,
+									},
+									{
+										element: <AdminLevelEditorPage />,
+										path: AppRoute.ADMIN_GAME_LEVEL_EDITOR,
+									},
 								],
 								element: <AdminLayout />,
 								path: AppRoute.ADMIN_ROOT,

--- a/src/libs/modules/localization/locales/en/admin.ts
+++ b/src/libs/modules/localization/locales/en/admin.ts
@@ -1,7 +1,21 @@
 const admin = {
+	errors: {
+		gameNotFound: "Game not found",
+		invalidGameId: "Invalid game id",
+		invalidLevelId: "Invalid level id",
+		unsupportedGame: "Admin is not available for this game ({{key}})",
+	},
 	header: {
 		loggedInAs: "Logged in as {{name}}",
 		title: "Admin",
+	},
+	nav: {
+		findTheWrong: "Find the wrong",
+		gameUnavailable: "This game is not available right now",
+	},
+	welcome: {
+		description: "Pick a game in the sidebar to manage its levels.",
+		title: "Administration",
 	},
 };
 

--- a/src/libs/modules/localization/locales/es/admin.ts
+++ b/src/libs/modules/localization/locales/es/admin.ts
@@ -1,6 +1,20 @@
 const admin = {
+	errors: {
+		gameNotFound: "Juego no encontrado",
+		invalidGameId: "Identificador de juego no válido",
+		invalidLevelId: "Identificador de nivel no válido",
+		unsupportedGame: "La administración no está disponible para este juego ({{key}})",
+	},
 	header: {
 		loggedInAs: "Conectado como {{name}}",
+		title: "Administración",
+	},
+	nav: {
+		findTheWrong: "Encuentra lo incorrecto",
+		gameUnavailable: "Este juego no está disponible ahora",
+	},
+	welcome: {
+		description: "Elige un juego en la barra lateral para gestionar sus niveles.",
 		title: "Administración",
 	},
 };

--- a/src/libs/modules/localization/locales/uk/admin.ts
+++ b/src/libs/modules/localization/locales/uk/admin.ts
@@ -1,6 +1,20 @@
 const admin = {
+	errors: {
+		gameNotFound: "Гру не знайдено",
+		invalidGameId: "Некоректний ідентифікатор гри",
+		invalidLevelId: "Некоректний ідентифікатор рівня",
+		unsupportedGame: "Адмін-панель недоступна для цієї гри ({{key}})",
+	},
 	header: {
 		loggedInAs: "Ви увійшли як {{name}}",
+		title: "Адміністрування",
+	},
+	nav: {
+		findTheWrong: "Знайди хибне",
+		gameUnavailable: "Гра наразі недоступна",
+	},
+	welcome: {
+		description: "Оберіть гру у бічному меню, щоб переглянути її рівні.",
 		title: "Адміністрування",
 	},
 };

--- a/src/modules/admin/admin.ts
+++ b/src/modules/admin/admin.ts
@@ -1,1 +1,1 @@
-export { AdminLayout, RequireAdmin } from "./components/components";
+export { AdminLayout, AdminPageFallback, RequireAdmin } from "./components/components";

--- a/src/modules/admin/components/admin-page-fallback/admin-page-fallback.tsx
+++ b/src/modules/admin/components/admin-page-fallback/admin-page-fallback.tsx
@@ -1,0 +1,17 @@
+import { FallbackMessage } from "~/libs/components/components";
+
+import styles from "./styles.module.css";
+
+type Properties = {
+	message: string;
+};
+
+const AdminPageFallback: React.FC<Properties> = ({ message }) => {
+	return (
+		<div className={styles["admin-page-fallback"]}>
+			<FallbackMessage message={message} />
+		</div>
+	);
+};
+
+export { AdminPageFallback };

--- a/src/modules/admin/components/admin-page-fallback/styles.module.css
+++ b/src/modules/admin/components/admin-page-fallback/styles.module.css
@@ -1,0 +1,9 @@
+.admin-page-fallback {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md);
+	width: 100%;
+	max-width: var(--container-max-width);
+	padding: var(--spacing-md);
+	margin: 0 auto;
+}

--- a/src/modules/admin/components/components.ts
+++ b/src/modules/admin/components/components.ts
@@ -1,2 +1,3 @@
 export { AdminLayout } from "./admin-layout/admin-layout";
+export { AdminPageFallback } from "./admin-page-fallback/admin-page-fallback";
 export { RequireAdmin } from "./require-admin/require-admin";

--- a/src/modules/admin/components/sidebar-nav/sidebar-nav.tsx
+++ b/src/modules/admin/components/sidebar-nav/sidebar-nav.tsx
@@ -1,7 +1,103 @@
+import { NavLink } from "react-router-dom";
+
+import { DataStatus } from "~/libs/enums/enums";
+import { getValidClassNames } from "~/libs/helpers/helpers";
+import {
+	useAppDispatch,
+	useAppSelector,
+	useCallback,
+	useEffect,
+	useLanguageSync,
+	useTranslation,
+} from "~/libs/hooks/hooks";
+import { actions as gamesActions } from "~/modules/games/games";
+
+import { ADMIN_GAMES_REGISTRY } from "../../libs/constants/admin-games-registry.constants";
+import { buildAdminLevelsListUrl } from "../../libs/helpers/build-admin-levels-list-url.helper";
 import styles from "./styles.module.css";
 
+type ItemClassNameOptions = {
+	isActive: boolean;
+	isDisabled: boolean;
+};
+
+const getItemClassName = ({ isActive, isDisabled }: ItemClassNameOptions): string =>
+	getValidClassNames(
+		styles["sidebar-nav__item"],
+		isActive && styles["sidebar-nav__item--active"],
+		isDisabled && styles["sidebar-nav__item--disabled"]
+	);
+
+const getNavLinkClassName = ({ isActive }: { isActive: boolean }): string =>
+	getItemClassName({ isActive, isDisabled: false });
+
 const SidebarNav: React.FC = () => {
-	return <nav className={styles["sidebar-nav"]} />;
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+	const games = useAppSelector((state) => state.games.games);
+	const gamesStatus = useAppSelector((state) => state.games.gamesStatus);
+
+	const fetchGames = useCallback((): void => {
+		void dispatch(gamesActions.getAllGames());
+	}, [dispatch]);
+
+	useEffect(() => {
+		if (gamesStatus === DataStatus.IDLE) {
+			fetchGames();
+		}
+	}, [fetchGames, gamesStatus]);
+
+	useLanguageSync(fetchGames);
+
+	const isLoading = gamesStatus === DataStatus.IDLE || gamesStatus === DataStatus.PENDING;
+
+	if (isLoading) {
+		return (
+			<nav className={styles["sidebar-nav"]}>
+				{ADMIN_GAMES_REGISTRY.map(({ gameKey }) => (
+					<span
+						aria-busy="true"
+						className={getValidClassNames(
+							styles["sidebar-nav__item"],
+							styles["sidebar-nav__item--skeleton"]
+						)}
+						key={gameKey}
+					/>
+				))}
+			</nav>
+		);
+	}
+
+	return (
+		<nav className={styles["sidebar-nav"]}>
+			{ADMIN_GAMES_REGISTRY.map(({ gameKey, labelKey }) => {
+				const game = games.find((entry) => entry.key === gameKey);
+
+				if (!game) {
+					return (
+						<span
+							aria-disabled="true"
+							className={getItemClassName({ isActive: false, isDisabled: true })}
+							key={gameKey}
+							title={t("admin.nav.gameUnavailable")}
+						>
+							{t(labelKey)}
+						</span>
+					);
+				}
+
+				return (
+					<NavLink
+						className={getNavLinkClassName}
+						key={gameKey}
+						to={buildAdminLevelsListUrl(game.id)}
+					>
+						{game.title}
+					</NavLink>
+				);
+			})}
+		</nav>
+	);
 };
 
 export { SidebarNav };

--- a/src/modules/admin/components/sidebar-nav/styles.module.css
+++ b/src/modules/admin/components/sidebar-nav/styles.module.css
@@ -11,3 +11,45 @@
 	background-color: var(--color-background-light-gray);
 	border-right: 1px solid var(--color-dark-border-subtle);
 }
+
+.sidebar-nav__item {
+	padding: var(--spacing-xs) var(--spacing-sm);
+	font-size: var(--font-size-xs);
+	font-weight: var(--font-weight-medium);
+	color: var(--color-text-1);
+	text-decoration: none;
+	background-color: transparent;
+	border-radius: var(--border-radius-sm);
+	transition:
+		background-color var(--transition-default),
+		color var(--transition-default);
+}
+
+.sidebar-nav__item:hover {
+	background-color: var(--color-background-2);
+}
+
+.sidebar-nav__item--active {
+	color: var(--color-text-light);
+	background-color: var(--color-background-accent);
+}
+
+.sidebar-nav__item--active:hover {
+	background-color: var(--color-background-accent);
+}
+
+.sidebar-nav__item--disabled {
+	color: var(--color-text-2);
+	cursor: not-allowed;
+}
+
+.sidebar-nav__item--disabled:hover {
+	background-color: transparent;
+}
+
+.sidebar-nav__item--skeleton {
+	height: 1.5rem;
+	background-color: var(--color-background-2);
+	border-radius: var(--border-radius-sm);
+	opacity: 0.5;
+}

--- a/src/modules/admin/games/find-the-wrong/components/components.ts
+++ b/src/modules/admin/games/find-the-wrong/components/components.ts
@@ -1,0 +1,2 @@
+export { FindTheWrongEditorSection } from "./find-the-wrong-editor-section/find-the-wrong-editor-section";
+export { FindTheWrongLevelsListSection } from "./find-the-wrong-levels-list-section/find-the-wrong-levels-list-section";

--- a/src/modules/admin/games/find-the-wrong/components/find-the-wrong-editor-section/find-the-wrong-editor-section.tsx
+++ b/src/modules/admin/games/find-the-wrong/components/find-the-wrong-editor-section/find-the-wrong-editor-section.tsx
@@ -1,0 +1,18 @@
+import { type AdminLevelEditorSectionProperties } from "~/modules/admin/libs/types/admin-level-editor-section-properties.type";
+
+import styles from "../section.module.css";
+
+const FindTheWrongEditorSection: React.FC<AdminLevelEditorSectionProperties> = ({
+	game,
+	levelId,
+}) => {
+	return (
+		<section className={styles["section"]}>
+			<h2 className={styles["section__title"]}>
+				{game.title} — Editor: level {levelId}
+			</h2>
+		</section>
+	);
+};
+
+export { FindTheWrongEditorSection };

--- a/src/modules/admin/games/find-the-wrong/components/find-the-wrong-levels-list-section/find-the-wrong-levels-list-section.tsx
+++ b/src/modules/admin/games/find-the-wrong/components/find-the-wrong-levels-list-section/find-the-wrong-levels-list-section.tsx
@@ -1,0 +1,13 @@
+import { type AdminLevelsListSectionProperties } from "~/modules/admin/libs/types/admin-levels-list-section-properties.type";
+
+import styles from "../section.module.css";
+
+const FindTheWrongLevelsListSection: React.FC<AdminLevelsListSectionProperties> = ({ game }) => {
+	return (
+		<section className={styles["section"]}>
+			<h2 className={styles["section__title"]}>Levels for {game.title}</h2>
+		</section>
+	);
+};
+
+export { FindTheWrongLevelsListSection };

--- a/src/modules/admin/games/find-the-wrong/components/section.module.css
+++ b/src/modules/admin/games/find-the-wrong/components/section.module.css
@@ -1,0 +1,12 @@
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm);
+}
+
+.section__title {
+	margin: 0;
+	font-size: var(--font-size-md);
+	font-weight: var(--font-weight-semibold);
+	color: var(--color-text-dark);
+}

--- a/src/modules/admin/games/find-the-wrong/find-the-wrong-admin.ts
+++ b/src/modules/admin/games/find-the-wrong/find-the-wrong-admin.ts
@@ -1,0 +1,1 @@
+export { FindTheWrongEditorSection, FindTheWrongLevelsListSection } from "./components/components";

--- a/src/modules/admin/libs/constants/admin-games-registry.constants.ts
+++ b/src/modules/admin/libs/constants/admin-games-registry.constants.ts
@@ -1,0 +1,18 @@
+import { GameKey } from "~/libs/enums/enums";
+import {
+	FindTheWrongEditorSection,
+	FindTheWrongLevelsListSection,
+} from "~/modules/admin/games/find-the-wrong/find-the-wrong-admin";
+
+import { type AdminGameRegistration } from "../types/admin-game-registration.type";
+
+const ADMIN_GAMES_REGISTRY: readonly AdminGameRegistration[] = [
+	{
+		EditorSection: FindTheWrongEditorSection,
+		gameKey: GameKey.FIND_THE_WRONG,
+		labelKey: "admin.nav.findTheWrong",
+		LevelsListSection: FindTheWrongLevelsListSection,
+	},
+];
+
+export { ADMIN_GAMES_REGISTRY };

--- a/src/modules/admin/libs/helpers/build-admin-levels-list-url.helper.ts
+++ b/src/modules/admin/libs/helpers/build-admin-levels-list-url.helper.ts
@@ -1,0 +1,7 @@
+import { AppRoute } from "~/libs/enums/enums";
+
+const buildAdminLevelsListUrl = (gameId: string): string => {
+	return AppRoute.ADMIN_GAME_LEVELS.replace(":gameId", gameId);
+};
+
+export { buildAdminLevelsListUrl };

--- a/src/modules/admin/libs/helpers/find-admin-game-registration.helper.ts
+++ b/src/modules/admin/libs/helpers/find-admin-game-registration.helper.ts
@@ -1,0 +1,8 @@
+import { ADMIN_GAMES_REGISTRY } from "../constants/admin-games-registry.constants";
+import { type AdminGameRegistration } from "../types/admin-game-registration.type";
+
+const findAdminGameRegistration = (gameKey: string): AdminGameRegistration | null => {
+	return ADMIN_GAMES_REGISTRY.find((entry) => entry.gameKey === gameKey) ?? null;
+};
+
+export { findAdminGameRegistration };

--- a/src/modules/admin/libs/helpers/parse-level-id.helper.ts
+++ b/src/modules/admin/libs/helpers/parse-level-id.helper.ts
@@ -1,0 +1,17 @@
+const MIN_LEVEL_ID = 1;
+
+const parseLevelId = (raw?: string): null | number => {
+	if (!raw) {
+		return null;
+	}
+
+	const parsed = Number(raw);
+
+	if (!Number.isInteger(parsed) || parsed < MIN_LEVEL_ID) {
+		return null;
+	}
+
+	return parsed;
+};
+
+export { parseLevelId };

--- a/src/modules/admin/libs/types/admin-game-registration.type.ts
+++ b/src/modules/admin/libs/types/admin-game-registration.type.ts
@@ -1,0 +1,13 @@
+import { type GameKeyType } from "~/libs/enums/enums";
+
+import { type AdminLevelEditorSectionProperties } from "./admin-level-editor-section-properties.type";
+import { type AdminLevelsListSectionProperties } from "./admin-levels-list-section-properties.type";
+
+type AdminGameRegistration = {
+	EditorSection: React.FC<AdminLevelEditorSectionProperties>;
+	gameKey: GameKeyType;
+	labelKey: string;
+	LevelsListSection: React.FC<AdminLevelsListSectionProperties>;
+};
+
+export { type AdminGameRegistration };

--- a/src/modules/admin/libs/types/admin-level-editor-section-properties.type.ts
+++ b/src/modules/admin/libs/types/admin-level-editor-section-properties.type.ts
@@ -1,0 +1,8 @@
+import { type GameDescriptionDto } from "~/libs/types/types";
+
+type AdminLevelEditorSectionProperties = {
+	game: GameDescriptionDto;
+	levelId: number;
+};
+
+export { type AdminLevelEditorSectionProperties };

--- a/src/modules/admin/libs/types/admin-levels-list-section-properties.type.ts
+++ b/src/modules/admin/libs/types/admin-levels-list-section-properties.type.ts
@@ -1,0 +1,7 @@
+import { type GameDescriptionDto } from "~/libs/types/types";
+
+type AdminLevelsListSectionProperties = {
+	game: GameDescriptionDto;
+};
+
+export { type AdminLevelsListSectionProperties };

--- a/src/pages/admin/admin-level-editor-page/admin-level-editor-page.tsx
+++ b/src/pages/admin/admin-level-editor-page/admin-level-editor-page.tsx
@@ -9,8 +9,8 @@ import styles from "./styles.module.css";
 const AdminLevelEditorPage: React.FC = () => {
 	const { t } = useTranslation();
 	const { gameId, levelId } = useParams();
-	const { currentGame, isLoading } = useGameFetch(gameId);
 	const parsedLevelId = parseLevelId(levelId);
+	const { currentGame, isLoading } = useGameFetch(parsedLevelId === null ? undefined : gameId);
 
 	if (!gameId) {
 		return <AdminPageFallback message={t("admin.errors.invalidGameId")} />;

--- a/src/pages/admin/admin-level-editor-page/admin-level-editor-page.tsx
+++ b/src/pages/admin/admin-level-editor-page/admin-level-editor-page.tsx
@@ -1,0 +1,44 @@
+import { Loader } from "~/libs/components/components";
+import { useGameFetch, useParams, useTranslation } from "~/libs/hooks/hooks";
+import { AdminPageFallback } from "~/modules/admin/admin";
+import { findAdminGameRegistration } from "~/modules/admin/libs/helpers/find-admin-game-registration.helper";
+import { parseLevelId } from "~/modules/admin/libs/helpers/parse-level-id.helper";
+
+import styles from "./styles.module.css";
+
+const AdminLevelEditorPage: React.FC = () => {
+	const { t } = useTranslation();
+	const { gameId, levelId } = useParams();
+	const { currentGame, isLoading } = useGameFetch(gameId);
+	const parsedLevelId = parseLevelId(levelId);
+
+	if (!gameId) {
+		return <AdminPageFallback message={t("admin.errors.invalidGameId")} />;
+	}
+
+	if (parsedLevelId === null) {
+		return <AdminPageFallback message={t("admin.errors.invalidLevelId")} />;
+	}
+
+	if (isLoading) {
+		return <Loader variant="overlay" />;
+	}
+
+	if (!currentGame) {
+		return <AdminPageFallback message={t("admin.errors.gameNotFound")} />;
+	}
+
+	const Section = findAdminGameRegistration(currentGame.key)?.EditorSection ?? null;
+
+	if (!Section) {
+		return <AdminPageFallback message={t("admin.errors.unsupportedGame", { key: currentGame.key })} />;
+	}
+
+	return (
+		<div className={styles["page"]}>
+			<Section game={currentGame} levelId={parsedLevelId} />
+		</div>
+	);
+};
+
+export { AdminLevelEditorPage };

--- a/src/pages/admin/admin-level-editor-page/styles.module.css
+++ b/src/pages/admin/admin-level-editor-page/styles.module.css
@@ -1,0 +1,8 @@
+.page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md);
+	width: 100%;
+	max-width: var(--container-max-width);
+	margin: 0 auto;
+}

--- a/src/pages/admin/admin-levels-list-page/admin-levels-list-page.tsx
+++ b/src/pages/admin/admin-levels-list-page/admin-levels-list-page.tsx
@@ -1,0 +1,38 @@
+import { Loader } from "~/libs/components/components";
+import { useGameFetch, useParams, useTranslation } from "~/libs/hooks/hooks";
+import { AdminPageFallback } from "~/modules/admin/admin";
+import { findAdminGameRegistration } from "~/modules/admin/libs/helpers/find-admin-game-registration.helper";
+
+import styles from "./styles.module.css";
+
+const AdminLevelsListPage: React.FC = () => {
+	const { t } = useTranslation();
+	const { gameId } = useParams();
+	const { currentGame, isLoading } = useGameFetch(gameId);
+
+	if (!gameId) {
+		return <AdminPageFallback message={t("admin.errors.invalidGameId")} />;
+	}
+
+	if (isLoading) {
+		return <Loader variant="overlay" />;
+	}
+
+	if (!currentGame) {
+		return <AdminPageFallback message={t("admin.errors.gameNotFound")} />;
+	}
+
+	const Section = findAdminGameRegistration(currentGame.key)?.LevelsListSection ?? null;
+
+	if (!Section) {
+		return <AdminPageFallback message={t("admin.errors.unsupportedGame", { key: currentGame.key })} />;
+	}
+
+	return (
+		<div className={styles["page"]}>
+			<Section game={currentGame} />
+		</div>
+	);
+};
+
+export { AdminLevelsListPage };

--- a/src/pages/admin/admin-levels-list-page/styles.module.css
+++ b/src/pages/admin/admin-levels-list-page/styles.module.css
@@ -1,0 +1,8 @@
+.page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-md);
+	width: 100%;
+	max-width: var(--container-max-width);
+	margin: 0 auto;
+}

--- a/src/pages/admin/admin-welcome-page/admin-welcome-page.tsx
+++ b/src/pages/admin/admin-welcome-page/admin-welcome-page.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from "~/libs/hooks/hooks";
+
+import styles from "./styles.module.css";
+
+const AdminWelcomePage: React.FC = () => {
+	const { t } = useTranslation();
+
+	return (
+		<div className={styles["page"]}>
+			<h1 className={styles["page__title"]}>{t("admin.welcome.title")}</h1>
+			<p className={styles["page__description"]}>{t("admin.welcome.description")}</p>
+		</div>
+	);
+};
+
+export { AdminWelcomePage };

--- a/src/pages/admin/admin-welcome-page/styles.module.css
+++ b/src/pages/admin/admin-welcome-page/styles.module.css
@@ -1,0 +1,21 @@
+.page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm);
+	width: 100%;
+	max-width: var(--container-max-width);
+	margin: 0 auto;
+}
+
+.page__title {
+	margin: 0;
+	font-size: var(--font-size-lg);
+	font-weight: var(--font-weight-semibold);
+	color: var(--color-text-dark);
+}
+
+.page__description {
+	margin: 0;
+	font-size: var(--font-size-sm);
+	color: var(--color-text-secondary);
+}

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -1,3 +1,6 @@
+export { AdminLevelEditorPage } from "./admin/admin-level-editor-page/admin-level-editor-page";
+export { AdminLevelsListPage } from "./admin/admin-levels-list-page/admin-levels-list-page";
+export { AdminWelcomePage } from "./admin/admin-welcome-page/admin-welcome-page";
 export { AuthGoogleCallbackPage } from "./auth-google-callback-page/auth-google-callback-page";
 export { GameContentPage } from "./game-content-page/game-content-page";
 export { GameSelectionPage } from "./game-selection-page/game-selection-page";

--- a/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
+++ b/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
@@ -13,6 +13,7 @@ import { DataStatus } from "~/libs/enums/enums";
 import { i18n } from "~/libs/modules/localization/i18n";
 import { AdminLayout } from "~/modules/admin/components/admin-layout/admin-layout";
 import { reducer as authReducer } from "~/modules/auth/slices/auth.slice";
+import { reducer as gamesReducer } from "~/modules/games/games";
 
 const mockLogout = vi.fn();
 
@@ -34,9 +35,18 @@ const renderAdminLayout = (): ReturnType<typeof render> => {
 				isAuthenticated: true,
 				user: { email: "a@a.com", id: 1, is_admin: true, name: "Admin" },
 			},
+			games: {
+				currentGame: null,
+				currentGameLevels: null,
+				currentGameStatus: DataStatus.IDLE,
+				games: [],
+				gamesStatus: DataStatus.FULFILLED,
+				levelsStatus: DataStatus.IDLE,
+			},
 		},
 		reducer: {
 			auth: authReducer,
+			games: gamesReducer,
 		},
 	});
 

--- a/tests/modules/admin/components/sidebar-nav/sidebar-nav.spec.tsx
+++ b/tests/modules/admin/components/sidebar-nav/sidebar-nav.spec.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { configureStore } from "@reduxjs/toolkit";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import { DataStatus, GameKey, type GameKeyType } from "~/libs/enums/enums";
+import { SidebarNav } from "~/modules/admin/components/sidebar-nav/sidebar-nav";
+import { reducer as gamesReducer } from "~/modules/games/games";
+
+type GamesPreload = {
+	games: { id: string; key: string }[];
+	gamesStatus: (typeof DataStatus)[keyof typeof DataStatus];
+};
+
+const buildStore = ({ games, gamesStatus }: GamesPreload): ReturnType<typeof configureStore> =>
+	configureStore({
+		preloadedState: {
+			games: {
+				currentGame: null,
+				currentGameLevels: null,
+				currentGameStatus: DataStatus.IDLE,
+				games: games.map((entry) => ({
+					description: "",
+					icon_url: "",
+					id: entry.id,
+					isActive: true,
+					key: entry.key as GameKeyType,
+					title: entry.key,
+				})),
+				gamesStatus,
+				levelsStatus: DataStatus.IDLE,
+			},
+		},
+		reducer: { games: gamesReducer },
+	});
+
+const renderSidebar = (preload: GamesPreload): ReturnType<typeof configureStore> => {
+	const store = buildStore(preload);
+
+	render(
+		<Provider store={store}>
+			<MemoryRouter>
+				<SidebarNav />
+			</MemoryRouter>
+		</Provider>
+	);
+
+	return store;
+};
+
+describe("SidebarNav", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders a NavLink with resolved gameId once the matching game is loaded", () => {
+		renderSidebar({
+			games: [{ id: "42", key: GameKey.FIND_THE_WRONG }],
+			gamesStatus: DataStatus.FULFILLED,
+		});
+
+		const link = screen.getByRole("link");
+
+		expect(link).toHaveAttribute("href", "/admin/games/42/levels");
+	});
+
+	it("renders a disabled placeholder when no matching game is in the slice yet", () => {
+		renderSidebar({ games: [], gamesStatus: DataStatus.FULFILLED });
+
+		expect(screen.queryByRole("link")).not.toBeInTheDocument();
+	});
+
+	it("dispatches getAllGames when the games slice is IDLE (single fetch owner)", async () => {
+		const store = renderSidebar({ games: [], gamesStatus: DataStatus.IDLE });
+
+		await waitFor(() => {
+			const state = store.getState() as { games: { gamesStatus: string } };
+
+			expect(state.games.gamesStatus).not.toBe(DataStatus.IDLE);
+		});
+	});
+
+	it("does not dispatch getAllGames when the slice is already PENDING or FULFILLED", () => {
+		const store = buildStore({
+			games: [{ id: "42", key: GameKey.FIND_THE_WRONG }],
+			gamesStatus: DataStatus.FULFILLED,
+		});
+		const spy = vi.spyOn(store, "dispatch");
+
+		render(
+			<Provider store={store}>
+				<MemoryRouter>
+					<SidebarNav />
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(spy).not.toHaveBeenCalled();
+
+		spy.mockRestore();
+	});
+});

--- a/tests/modules/admin/libs/helpers/find-admin-game-registration.helper.spec.ts
+++ b/tests/modules/admin/libs/helpers/find-admin-game-registration.helper.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { GameKey } from "~/libs/enums/enums";
+import { findAdminGameRegistration } from "~/modules/admin/libs/helpers/find-admin-game-registration.helper";
+
+describe("findAdminGameRegistration", () => {
+	it("returns the registration for an admin-supported game key", () => {
+		const registration = findAdminGameRegistration(GameKey.FIND_THE_WRONG);
+
+		expect(registration).not.toBeNull();
+		expect(registration?.gameKey).toBe(GameKey.FIND_THE_WRONG);
+		expect(typeof registration?.EditorSection).toBe("function");
+		expect(typeof registration?.LevelsListSection).toBe("function");
+	});
+
+	it("returns null for a game key without admin support", () => {
+		expect(findAdminGameRegistration(GameKey.TRUE_FALSE_TEXT)).toBeNull();
+	});
+
+	it("returns null for an unknown game key", () => {
+		expect(findAdminGameRegistration("unknown_game")).toBeNull();
+	});
+});

--- a/tests/modules/admin/libs/helpers/parse-level-id.helper.spec.ts
+++ b/tests/modules/admin/libs/helpers/parse-level-id.helper.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { parseLevelId } from "~/modules/admin/libs/helpers/parse-level-id.helper";
+
+describe("parseLevelId", () => {
+	it("returns the parsed integer for a positive integer string", () => {
+		expect(parseLevelId("42")).toBe(42);
+	});
+
+	it("returns 1 for the minimum valid level id", () => {
+		expect(parseLevelId("1")).toBe(1);
+	});
+
+	it("returns null for undefined", () => {
+		expect(parseLevelId()).toBeNull();
+	});
+
+	it("returns null for an empty string", () => {
+		expect(parseLevelId("")).toBeNull();
+	});
+
+	it("returns null for a non-numeric string", () => {
+		expect(parseLevelId("abc")).toBeNull();
+	});
+
+	it("returns null for a float", () => {
+		expect(parseLevelId("4.2")).toBeNull();
+	});
+
+	it("returns null for zero", () => {
+		expect(parseLevelId("0")).toBeNull();
+	});
+
+	it("returns null for a negative integer", () => {
+		expect(parseLevelId("-5")).toBeNull();
+	});
+});

--- a/tests/pages/admin/admin-level-editor-page/admin-level-editor-page.spec.tsx
+++ b/tests/pages/admin/admin-level-editor-page/admin-level-editor-page.spec.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type * as hooksModule from "~/libs/hooks/hooks";
+
+import { GameKey } from "~/libs/enums/enums";
+import { type GameDescriptionDto } from "~/libs/types/types";
+import { AdminLevelEditorPage } from "~/pages/admin/admin-level-editor-page/admin-level-editor-page";
+
+type UseGameFetchReturn = {
+	currentGame: GameDescriptionDto | null;
+	isLoading: boolean;
+};
+
+const mockUseGameFetch = vi.fn<() => UseGameFetchReturn>();
+
+vi.mock("~/libs/hooks/hooks", async (importOriginal) => {
+	const actual = await importOriginal<typeof hooksModule>();
+
+	return {
+		...actual,
+		useGameFetch: () => mockUseGameFetch(),
+	};
+});
+
+const buildGame = (key: string): GameDescriptionDto => ({
+	description: "Find the wrong description",
+	icon_url: "",
+	id: "42",
+	isActive: true,
+	key: key as GameDescriptionDto["key"],
+	title: "Find the wrong",
+});
+
+const renderAt = (path: string): ReturnType<typeof render> =>
+	render(
+		<MemoryRouter initialEntries={[path]}>
+			<Routes>
+				<Route
+					element={<AdminLevelEditorPage />}
+					path="/admin/games/:gameId/levels/:levelId"
+				/>
+			</Routes>
+		</MemoryRouter>
+	);
+
+describe("AdminLevelEditorPage", () => {
+	afterEach(() => {
+		cleanup();
+		mockUseGameFetch.mockReset();
+	});
+
+	it("renders the FindTheWrong editor when game key is registered and levelId is valid", () => {
+		mockUseGameFetch.mockReturnValue({
+			currentGame: buildGame(GameKey.FIND_THE_WRONG),
+			isLoading: false,
+		});
+
+		renderAt("/admin/games/42/levels/7");
+
+		expect(screen.getByRole("heading", { name: /Editor: level 7/i })).toBeInTheDocument();
+	});
+
+	it("rejects non-numeric levelId before fetching game", () => {
+		mockUseGameFetch.mockReturnValue({
+			currentGame: buildGame(GameKey.FIND_THE_WRONG),
+			isLoading: false,
+		});
+
+		renderAt("/admin/games/42/levels/abc");
+
+		expect(screen.getByText(/Invalid level id/i)).toBeInTheDocument();
+	});
+
+	it("falls back to unsupportedGame for keys without an editor", () => {
+		mockUseGameFetch.mockReturnValue({
+			currentGame: buildGame(GameKey.TRUE_FALSE_IMAGE),
+			isLoading: false,
+		});
+
+		renderAt("/admin/games/42/levels/7");
+
+		expect(screen.getByText(/Admin is not available for this game/i)).toBeInTheDocument();
+	});
+});

--- a/tests/pages/admin/admin-level-editor-page/admin-level-editor-page.spec.tsx
+++ b/tests/pages/admin/admin-level-editor-page/admin-level-editor-page.spec.tsx
@@ -15,14 +15,14 @@ type UseGameFetchReturn = {
 	isLoading: boolean;
 };
 
-const mockUseGameFetch = vi.fn<() => UseGameFetchReturn>();
+const mockUseGameFetch = vi.fn<(id: string | undefined) => UseGameFetchReturn>();
 
 vi.mock("~/libs/hooks/hooks", async (importOriginal) => {
 	const actual = await importOriginal<typeof hooksModule>();
 
 	return {
 		...actual,
-		useGameFetch: () => mockUseGameFetch(),
+		useGameFetch: (id: string | undefined) => mockUseGameFetch(id),
 	};
 });
 
@@ -73,6 +73,15 @@ describe("AdminLevelEditorPage", () => {
 		renderAt("/admin/games/42/levels/abc");
 
 		expect(screen.getByText(/Invalid level id/i)).toBeInTheDocument();
+	});
+
+	it("does not fetch the game when levelId is invalid", () => {
+		mockUseGameFetch.mockReturnValue({ currentGame: null, isLoading: false });
+
+		renderAt("/admin/games/42/levels/abc");
+
+		expect(mockUseGameFetch).toHaveBeenCalledWith(undefined);
+		expect(mockUseGameFetch).not.toHaveBeenCalledWith("42");
 	});
 
 	it("falls back to unsupportedGame for keys without an editor", () => {

--- a/tests/pages/admin/admin-levels-list-page/admin-levels-list-page.spec.tsx
+++ b/tests/pages/admin/admin-levels-list-page/admin-levels-list-page.spec.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+import type * as hooksModule from "~/libs/hooks/hooks";
+
+import { GameKey } from "~/libs/enums/enums";
+import { type GameDescriptionDto } from "~/libs/types/types";
+import { AdminLevelsListPage } from "~/pages/admin/admin-levels-list-page/admin-levels-list-page";
+
+type UseGameFetchReturn = {
+	currentGame: GameDescriptionDto | null;
+	isLoading: boolean;
+};
+
+const mockUseGameFetch = vi.fn<() => UseGameFetchReturn>();
+
+vi.mock("~/libs/hooks/hooks", async (importOriginal) => {
+	const actual = await importOriginal<typeof hooksModule>();
+
+	return {
+		...actual,
+		useGameFetch: () => mockUseGameFetch(),
+	};
+});
+
+const buildGame = (key: string): GameDescriptionDto => ({
+	description: "Find the wrong description",
+	icon_url: "",
+	id: "42",
+	isActive: true,
+	key: key as GameDescriptionDto["key"],
+	title: "Find the wrong",
+});
+
+const renderAt = (path: string): ReturnType<typeof render> =>
+	render(
+		<MemoryRouter initialEntries={[path]}>
+			<Routes>
+				<Route element={<AdminLevelsListPage />} path="/admin/games/:gameId/levels" />
+			</Routes>
+		</MemoryRouter>
+	);
+
+describe("AdminLevelsListPage", () => {
+	afterEach(() => {
+		cleanup();
+		mockUseGameFetch.mockReset();
+	});
+
+	it("renders the FindTheWrong section when game key is registered", () => {
+		mockUseGameFetch.mockReturnValue({
+			currentGame: buildGame(GameKey.FIND_THE_WRONG),
+			isLoading: false,
+		});
+
+		renderAt("/admin/games/42/levels");
+
+		expect(screen.getByRole("heading", { name: /Find the wrong/i })).toBeInTheDocument();
+	});
+
+	it("falls back to unsupportedGame message when game key has no section", () => {
+		mockUseGameFetch.mockReturnValue({
+			currentGame: buildGame(GameKey.TRUE_FALSE_TEXT),
+			isLoading: false,
+		});
+
+		renderAt("/admin/games/42/levels");
+
+		expect(screen.getByText(/Admin is not available for this game/i)).toBeInTheDocument();
+	});
+
+	it("falls back to gameNotFound message when game cannot be resolved", () => {
+		mockUseGameFetch.mockReturnValue({ currentGame: null, isLoading: false });
+
+		renderAt("/admin/games/999/levels");
+
+		expect(screen.getByText(/Game not found/i)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
 - [x] Create directory tree (mirrors existing src/pages/level-content-page/ pattern)
 - [x] Create admin-levels-list-page.tsx
 - [x] Create admin-level-editor-page.tsx
 - [x] In router-provider.tsx, populate the children of the admin tree