### PR TITLE
fix(games): refetch in useGameFetch when URL id differs from cached one ss-103

### DIFF
--- a/src/libs/hooks/use-game-fetch/use-game-fetch.hook.ts
+++ b/src/libs/hooks/use-game-fetch/use-game-fetch.hook.ts
@@ -14,7 +14,8 @@ type UseGameFetchReturn = {
 
 const useGameFetch = (id: string | undefined): UseGameFetchReturn => {
 	const dispatch = useAppDispatch();
-	const { currentGame, currentGameStatus } = useAppSelector((state) => state.games);
+	const currentGame = useAppSelector((state) => state.games.currentGame);
+	const currentGameStatus = useAppSelector((state) => state.games.currentGameStatus);
 
 	const fetchGame = useCallback(() => {
 		if (id) {
@@ -25,22 +26,18 @@ const useGameFetch = (id: string | undefined): UseGameFetchReturn => {
 	useLanguageSync(fetchGame);
 
 	useEffect(() => {
-		if (id && currentGameStatus === DataStatus.IDLE) {
-			fetchGame();
+		if (!id || currentGame?.id === id) {
+			return;
 		}
-	}, [id, currentGameStatus, fetchGame]);
 
-	useEffect(() => {
-		return (): void => {
-			dispatch(gamesActions.clearCurrentGame());
-		};
-	}, [dispatch]);
+		fetchGame();
+	}, [id, currentGame?.id, fetchGame]);
 
-	const isLoading =
-		currentGameStatus === DataStatus.PENDING || currentGameStatus === DataStatus.IDLE;
+	const matchedGame = currentGame?.id === id ? currentGame : null;
+	const isLoading = matchedGame === null && currentGameStatus !== DataStatus.REJECTED;
 
 	return {
-		currentGame,
+		currentGame: matchedGame,
 		isLoading,
 	};
 };

--- a/src/libs/hooks/use-levels-fetch/use-levels-fetch.hook.ts
+++ b/src/libs/hooks/use-levels-fetch/use-levels-fetch.hook.ts
@@ -13,6 +13,7 @@ type UseLevelsFetchReturn = {
 const useLevelsFetch = (id: string | undefined): UseLevelsFetchReturn => {
 	const dispatch = useAppDispatch();
 	const levelsStatus = useAppSelector((state) => state.games.levelsStatus);
+	const currentLevelsGameId = useAppSelector((state) => state.games.currentLevelsGameId);
 
 	const fetchLevels = useCallback(() => {
 		if (id) {
@@ -23,12 +24,15 @@ const useLevelsFetch = (id: string | undefined): UseLevelsFetchReturn => {
 	useLanguageSync(fetchLevels);
 
 	useEffect(() => {
-		if (id && levelsStatus === DataStatus.IDLE) {
-			fetchLevels();
+		if (!id || currentLevelsGameId === id) {
+			return;
 		}
-	}, [id, fetchLevels, levelsStatus]);
 
-	const isLoading = levelsStatus === DataStatus.PENDING || levelsStatus === DataStatus.IDLE;
+		fetchLevels();
+	}, [id, currentLevelsGameId, fetchLevels]);
+
+	const isMatched = id !== undefined && currentLevelsGameId === id;
+	const isLoading = !isMatched && levelsStatus !== DataStatus.REJECTED;
 
 	return {
 		isLoading,

--- a/src/modules/games/slices/games.slice.ts
+++ b/src/modules/games/slices/games.slice.ts
@@ -10,6 +10,7 @@ type State = {
 	currentGame: GameDescriptionDto | null;
 	currentGameLevels: LevelDescriptionDto[] | null;
 	currentGameStatus: ValueOf<typeof DataStatus>;
+	currentLevelsGameId: null | string;
 	games: GameDescriptionDto[];
 	gamesStatus: ValueOf<typeof DataStatus>;
 	levelsStatus: ValueOf<typeof DataStatus>;
@@ -19,6 +20,7 @@ const initialState: State = {
 	currentGame: null,
 	currentGameLevels: null,
 	currentGameStatus: DataStatus.IDLE,
+	currentLevelsGameId: null,
 	games: [],
 	gamesStatus: DataStatus.IDLE,
 	levelsStatus: DataStatus.IDLE,
@@ -52,6 +54,7 @@ const { actions, name, reducer } = createSlice({
 		builder.addCase(getLevelsList.fulfilled, (state, action) => {
 			state.levelsStatus = DataStatus.FULFILLED;
 			state.currentGameLevels = action.payload;
+			state.currentLevelsGameId = action.meta.arg;
 		});
 		builder.addCase(getLevelsList.rejected, (state) => {
 			state.levelsStatus = DataStatus.REJECTED;
@@ -59,14 +62,7 @@ const { actions, name, reducer } = createSlice({
 	},
 	initialState,
 	name: "games",
-	reducers: {
-		clearCurrentGame: (state) => {
-			state.currentGame = null;
-			state.currentGameLevels = null;
-			state.currentGameStatus = DataStatus.IDLE;
-			state.levelsStatus = DataStatus.IDLE;
-		},
-	},
+	reducers: {},
 });
 
 export { actions, name, reducer };

--- a/tests/libs/hooks/use-game-fetch/use-game-fetch.hook.spec.ts
+++ b/tests/libs/hooks/use-game-fetch/use-game-fetch.hook.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DataStatus } from "~/libs/enums/enums";
+import { type GameDescriptionDto, type ValueOf } from "~/libs/types/types";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockDispatch, mockGetById, mockUseLanguageSync } = vi.hoisted(() => {
+	const mockGetById = vi.fn((id: string) => ({ payload: id, type: "games/get-by-id" }));
+	const mockDispatch = vi.fn();
+	const mockUseLanguageSync = vi.fn<(callback: () => void) => void>();
+
+	return { mockDispatch, mockGetById, mockUseLanguageSync };
+});
+
+vi.mock("~/modules/games/slices/games", () => ({
+	actions: { getById: mockGetById },
+}));
+
+vi.mock("~/libs/hooks/use-app-dispatch/use-app-dispatch.hook", () => ({
+	useAppDispatch: (): typeof mockDispatch => mockDispatch,
+}));
+
+vi.mock("~/libs/hooks/use-app-selector/use-app-selector.hook", () => ({
+	useAppSelector: vi.fn(),
+}));
+
+vi.mock("~/libs/hooks/use-language-sync/use-language-sync.hook", () => ({
+	useLanguageSync: mockUseLanguageSync,
+}));
+
+// ─── Imports (after vi.mock calls) ───────────────────────────────────────────
+
+import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
+import { useGameFetch } from "~/libs/hooks/use-game-fetch/use-game-fetch.hook";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockUseAppSelector = vi.mocked(useAppSelector);
+
+type GamesState = {
+	currentGame: GameDescriptionDto | null;
+	currentGameStatus: ValueOf<typeof DataStatus>;
+};
+
+const makeGame = (id: string): GameDescriptionDto => ({
+	description: "A game",
+	icon_url: "/icon.svg",
+	id,
+	key: "find_the_wrong" as GameDescriptionDto["key"],
+	title: "Game",
+});
+
+const setMockState = (state: GamesState): void => {
+	mockUseAppSelector.mockImplementation((selector) =>
+		selector({ games: state } as unknown as Parameters<typeof selector>[0])
+	);
+};
+
+const renderGameFetch = (id: string | undefined) =>
+	renderHook((current: string | undefined) => useGameFetch(current), { initialProps: id });
+
+describe("useGameFetch", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("fetches on mount when no game is cached", () => {
+		setMockState({ currentGame: null, currentGameStatus: DataStatus.IDLE });
+
+		const { result } = renderGameFetch("1");
+
+		expect(mockGetById).toHaveBeenCalledWith("1");
+		expect(result.current.isLoading).toBe(true);
+		expect(result.current.currentGame).toBeNull();
+	});
+
+	it("does not refetch when the cached game already matches the id", () => {
+		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
+
+		const { result } = renderGameFetch("1");
+
+		expect(mockGetById).not.toHaveBeenCalled();
+		expect(result.current.isLoading).toBe(false);
+		expect(result.current.currentGame).toEqual(makeGame("1"));
+	});
+
+	it("does not dispatch again on rerender with the same id", () => {
+		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
+
+		const { rerender } = renderGameFetch("1");
+		rerender("1");
+
+		expect(mockGetById).not.toHaveBeenCalled();
+	});
+
+	it("refetches when the id changes to a game that is not cached", () => {
+		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
+
+		const { rerender } = renderGameFetch("1");
+		rerender("2");
+
+		expect(mockGetById).toHaveBeenCalledWith("2");
+	});
+
+	it("treats a cached game from a different id as loading (no stale data exposed)", () => {
+		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
+
+		const { result } = renderGameFetch("2");
+
+		expect(result.current.currentGame).toBeNull();
+		expect(result.current.isLoading).toBe(true);
+	});
+
+	it("stops loading on rejection so the consumer can show not-found", () => {
+		setMockState({ currentGame: null, currentGameStatus: DataStatus.REJECTED });
+
+		const { result } = renderGameFetch("1");
+
+		expect(result.current.currentGame).toBeNull();
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("registers a language-sync callback that refetches the game", () => {
+		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
+
+		let capturedCallback: (() => void) | undefined;
+		mockUseLanguageSync.mockImplementation((callback: () => void) => {
+			capturedCallback = callback;
+		});
+
+		renderGameFetch("1");
+
+		expect(capturedCallback).toBeDefined();
+
+		act(() => {
+			capturedCallback?.();
+		});
+
+		expect(mockGetById).toHaveBeenCalledWith("1");
+	});
+});

--- a/tests/libs/hooks/use-levels-fetch/use-levels-fetch.hook.spec.ts
+++ b/tests/libs/hooks/use-levels-fetch/use-levels-fetch.hook.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DataStatus } from "~/libs/enums/enums";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockDispatch, mockGetLevelsList, mockUseLanguageSync } = vi.hoisted(() => {
+	const mockGetLevelsList = vi.fn((id: string) => ({ payload: id, type: "games/get-levels" }));
+	const mockDispatch = vi.fn();
+	const mockUseLanguageSync = vi.fn<(callback: () => void) => void>();
+
+	return { mockDispatch, mockGetLevelsList, mockUseLanguageSync };
+});
+
+vi.mock("~/modules/games/slices/actions", () => ({
+	getLevelsList: mockGetLevelsList,
+}));
+
+vi.mock("~/libs/hooks/use-app-dispatch/use-app-dispatch.hook", () => ({
+	useAppDispatch: (): typeof mockDispatch => mockDispatch,
+}));
+
+vi.mock("~/libs/hooks/use-app-selector/use-app-selector.hook", () => ({
+	useAppSelector: vi.fn(),
+}));
+
+vi.mock("~/libs/hooks/use-language-sync/use-language-sync.hook", () => ({
+	useLanguageSync: mockUseLanguageSync,
+}));
+
+// ─── Imports (after vi.mock calls) ───────────────────────────────────────────
+
+import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
+import { useLevelsFetch } from "~/libs/hooks/use-levels-fetch/use-levels-fetch.hook";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockUseAppSelector = vi.mocked(useAppSelector);
+
+type GamesState = {
+	currentLevelsGameId: null | string;
+	levelsStatus: (typeof DataStatus)[keyof typeof DataStatus];
+};
+
+const setMockState = (state: GamesState): void => {
+	mockUseAppSelector.mockImplementation((selector) =>
+		selector({ games: state } as unknown as Parameters<typeof selector>[0])
+	);
+};
+
+const renderLevelsFetch = (id: string | undefined) =>
+	renderHook((current: string | undefined) => useLevelsFetch(current), { initialProps: id });
+
+describe("useLevelsFetch", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("fetches on mount when no levels are cached", () => {
+		setMockState({ currentLevelsGameId: null, levelsStatus: DataStatus.IDLE });
+
+		const { result } = renderLevelsFetch("1");
+
+		expect(mockGetLevelsList).toHaveBeenCalledWith("1");
+		expect(result.current.isLoading).toBe(true);
+	});
+
+	it("does not refetch when cached levels already belong to the id", () => {
+		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
+
+		const { result } = renderLevelsFetch("1");
+
+		expect(mockGetLevelsList).not.toHaveBeenCalled();
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("does not dispatch again on rerender with the same id", () => {
+		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
+
+		const { rerender } = renderLevelsFetch("1");
+		rerender("1");
+
+		expect(mockGetLevelsList).not.toHaveBeenCalled();
+	});
+
+	it("refetches when the id changes to a game whose levels are not cached", () => {
+		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
+
+		const { rerender } = renderLevelsFetch("1");
+		rerender("2");
+
+		expect(mockGetLevelsList).toHaveBeenCalledWith("2");
+	});
+
+	it("treats levels cached for a different id as loading (no stale levels exposed)", () => {
+		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
+
+		const { result } = renderLevelsFetch("2");
+
+		expect(result.current.isLoading).toBe(true);
+	});
+
+	it("stops loading on rejection so the consumer can show an error", () => {
+		setMockState({ currentLevelsGameId: null, levelsStatus: DataStatus.REJECTED });
+
+		const { result } = renderLevelsFetch("1");
+
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("registers a language-sync callback that refetches the levels", () => {
+		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
+
+		let capturedCallback: (() => void) | undefined;
+		mockUseLanguageSync.mockImplementation((callback: () => void) => {
+			capturedCallback = callback;
+		});
+
+		renderLevelsFetch("1");
+
+		expect(capturedCallback).toBeDefined();
+
+		act(() => {
+			capturedCallback?.();
+		});
+
+		expect(mockGetLevelsList).toHaveBeenCalledWith("1");
+	});
+});

--- a/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
+++ b/tests/modules/admin/components/admin-layout/admin-layout.spec.tsx
@@ -39,6 +39,7 @@ const renderAdminLayout = (): ReturnType<typeof render> => {
 				currentGame: null,
 				currentGameLevels: null,
 				currentGameStatus: DataStatus.IDLE,
+				currentLevelsGameId: null,
 				games: [],
 				gamesStatus: DataStatus.FULFILLED,
 				levelsStatus: DataStatus.IDLE,

--- a/tests/modules/admin/components/sidebar-nav/sidebar-nav.spec.tsx
+++ b/tests/modules/admin/components/sidebar-nav/sidebar-nav.spec.tsx
@@ -24,6 +24,7 @@ const buildStore = ({ games, gamesStatus }: GamesPreload): ReturnType<typeof con
 				currentGame: null,
 				currentGameLevels: null,
 				currentGameStatus: DataStatus.IDLE,
+				currentLevelsGameId: null,
 				games: games.map((entry) => ({
 					description: "",
 					icon_url: "",


### PR DESCRIPTION
 - [x] Replace the IDLE-based fetch condition with an id-based one in useGameFetch.
 - [x] Remove the unconditional clearCurrentGame cleanup effect.
 - [x] Confirm logout still clears currentGame via resettableRootReducer.
 - [x] Add tests/libs/hooks/use-game-fetch/ specs: same-id rerender = no extra dispatch; different-id rerender = getById(newId); mount without cached game = getById(id).