### PR TITLE
refactor(games): extract useFetchById (matched data + abort) and dedupe game/levels hooks ss-105

### DIFF
--- a/src/libs/components/game-levels-preview/game-levels-preview.tsx
+++ b/src/libs/components/game-levels-preview/game-levels-preview.tsx
@@ -1,6 +1,5 @@
 import { EMPTY_ARRAY_LENGTH } from "~/libs/constants/constants";
-import { DataStatus } from "~/libs/enums/enums";
-import { useAppSelector, useTranslation } from "~/libs/hooks/hooks";
+import { useTranslation } from "~/libs/hooks/hooks";
 import { type GameDescriptionDto, type LevelDescriptionDto } from "~/libs/types/types";
 
 import { GameLevelsContent } from "./game-levels-content/game-levels-content";
@@ -8,14 +7,13 @@ import styles from "./styles.module.css";
 
 type Properties = {
 	game: GameDescriptionDto;
+	hasError: boolean;
 	levels: LevelDescriptionDto[] | null;
 };
 
-const GameLevelsPreview: React.FC<Properties> = ({ game, levels }) => {
+const GameLevelsPreview: React.FC<Properties> = ({ game, hasError, levels }) => {
 	const { t } = useTranslation();
-	const levelsStatus = useAppSelector((state) => state.games.levelsStatus);
 
-	const hasError = levelsStatus === DataStatus.REJECTED;
 	const hasLevels = Boolean(levels && levels.length > EMPTY_ARRAY_LENGTH);
 
 	return (

--- a/src/libs/components/game-levels-preview/game-levels-preview.tsx
+++ b/src/libs/components/game-levels-preview/game-levels-preview.tsx
@@ -1,22 +1,22 @@
 import { EMPTY_ARRAY_LENGTH } from "~/libs/constants/constants";
 import { DataStatus } from "~/libs/enums/enums";
 import { useAppSelector, useTranslation } from "~/libs/hooks/hooks";
-import { type GameDescriptionDto } from "~/libs/types/types";
+import { type GameDescriptionDto, type LevelDescriptionDto } from "~/libs/types/types";
 
 import { GameLevelsContent } from "./game-levels-content/game-levels-content";
 import styles from "./styles.module.css";
 
 type Properties = {
 	game: GameDescriptionDto;
+	levels: LevelDescriptionDto[] | null;
 };
 
-const GameLevelsPreview: React.FC<Properties> = ({ game }) => {
+const GameLevelsPreview: React.FC<Properties> = ({ game, levels }) => {
 	const { t } = useTranslation();
-	const currentGameLevels = useAppSelector((state) => state.games.currentGameLevels);
 	const levelsStatus = useAppSelector((state) => state.games.levelsStatus);
 
 	const hasError = levelsStatus === DataStatus.REJECTED;
-	const hasLevels = Boolean(currentGameLevels && currentGameLevels.length > EMPTY_ARRAY_LENGTH);
+	const hasLevels = Boolean(levels && levels.length > EMPTY_ARRAY_LENGTH);
 
 	return (
 		<div className={styles["game-levels-preview__container"]}>
@@ -28,7 +28,7 @@ const GameLevelsPreview: React.FC<Properties> = ({ game }) => {
 					game={game}
 					hasError={hasError}
 					hasLevels={hasLevels}
-					levels={currentGameLevels ?? []}
+					levels={levels ?? []}
 				/>
 			</section>
 		</div>

--- a/src/libs/components/level-preview-card/styles.module.css
+++ b/src/libs/components/level-preview-card/styles.module.css
@@ -65,7 +65,11 @@
 }
 
 .card__image {
-	width: 100%;
+	width: calc(100% - 24px);
+	aspect-ratio: 200/200;
+	margin: 12px;
+	object-fit: cover;
+	object-position: center;
 	background: linear-gradient(180deg, var(--color-background-1), var(--color-background-2));
 }
 
@@ -73,8 +77,9 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 100%;
-	aspect-ratio: 200/120;
+	width: calc(100% - 24px);
+	aspect-ratio: 200/200;
+	margin: 12px;
 	font-size: 14px;
 	color: var(--color-text-muted);
 	background-color: var(--color-background-light-gray);

--- a/src/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.ts
+++ b/src/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.ts
@@ -8,6 +8,7 @@ import { useLanguageSync } from "~/libs/hooks/use-language-sync/use-language-syn
 import { type AsyncThunkConfig, type ValueOf } from "~/libs/types/types";
 
 type FetchByIdConfig<TData> = {
+	/** Must be a stable reference (module-level thunk creator), else the effect loops. */
 	createFetch: (id: string) => AsyncThunkAction<TData, string, AsyncThunkConfig>;
 	id: string | undefined;
 	selectData: (state: RootState) => null | TData;
@@ -17,6 +18,7 @@ type FetchByIdConfig<TData> = {
 
 type FetchByIdReturn<TData> = {
 	data: null | TData;
+	hasError: boolean;
 	isLoading: boolean;
 };
 
@@ -74,9 +76,11 @@ const useFetchById = <TData,>({
 
 	const isMatched = id !== undefined && loadedId === id;
 	const isLoading = id !== undefined && !isMatched && status !== DataStatus.REJECTED;
+	const hasError = id !== undefined && status === DataStatus.REJECTED;
 
 	return {
 		data: isMatched ? data : null,
+		hasError,
 		isLoading,
 	};
 };

--- a/src/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.ts
+++ b/src/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.ts
@@ -1,0 +1,84 @@
+import { type AsyncThunkAction } from "@reduxjs/toolkit";
+import { useCallback, useEffect, useRef } from "react";
+
+import { DataStatus } from "~/libs/enums/enums";
+import { useAppDispatch } from "~/libs/hooks/use-app-dispatch/use-app-dispatch.hook";
+import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
+import { useLanguageSync } from "~/libs/hooks/use-language-sync/use-language-sync.hook";
+import { type AsyncThunkConfig, type ValueOf } from "~/libs/types/types";
+
+type FetchByIdConfig<TData> = {
+	createFetch: (id: string) => AsyncThunkAction<TData, string, AsyncThunkConfig>;
+	id: string | undefined;
+	selectData: (state: RootState) => null | TData;
+	selectLoadedId: (state: RootState) => null | string;
+	selectStatus: (state: RootState) => ValueOf<typeof DataStatus>;
+};
+
+type FetchByIdReturn<TData> = {
+	data: null | TData;
+	isLoading: boolean;
+};
+
+type RootState = AsyncThunkConfig["state"];
+
+/**
+ * URL-driven fetch-by-id. The URL `id` is the source of truth: data is loaded
+ * whenever the cached resource belongs to a different id, the previous in-flight
+ * request is aborted, and `data` is exposed only when it matches the current id
+ * (never stale). Used by `useGameFetch`/`useLevelsFetch`.
+ */
+const useFetchById = <TData,>({
+	createFetch,
+	id,
+	selectData,
+	selectLoadedId,
+	selectStatus,
+}: FetchByIdConfig<TData>): FetchByIdReturn<TData> => {
+	const dispatch = useAppDispatch();
+	const status = useAppSelector(selectStatus);
+	const loadedId = useAppSelector(selectLoadedId);
+	const data = useAppSelector(selectData);
+
+	const abortReference = useRef<(() => void) | null>(null);
+
+	const fetchById = useCallback(() => {
+		if (!id) {
+			return;
+		}
+
+		abortReference.current?.();
+
+		const promise = dispatch(createFetch(id));
+
+		abortReference.current = (): void => {
+			promise.abort();
+		};
+	}, [dispatch, createFetch, id]);
+
+	useLanguageSync(fetchById);
+
+	useEffect(() => {
+		if (!id || loadedId === id) {
+			return;
+		}
+
+		fetchById();
+	}, [id, loadedId, fetchById]);
+
+	useEffect(() => {
+		return (): void => {
+			abortReference.current?.();
+		};
+	}, []);
+
+	const isMatched = id !== undefined && loadedId === id;
+	const isLoading = id !== undefined && !isMatched && status !== DataStatus.REJECTED;
+
+	return {
+		data: isMatched ? data : null,
+		isLoading,
+	};
+};
+
+export { useFetchById };

--- a/src/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.ts
+++ b/src/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.ts
@@ -43,18 +43,21 @@ const useFetchById = <TData,>({
 	const data = useAppSelector(selectData);
 
 	const abortReference = useRef<(() => void) | null>(null);
+	const attemptedIdReference = useRef<string | undefined>(undefined);
 
 	const fetchById = useCallback(() => {
 		if (!id) {
 			return;
 		}
 
+		attemptedIdReference.current = id;
 		abortReference.current?.();
 
 		const promise = dispatch(createFetch(id));
 
 		abortReference.current = (): void => {
 			promise.abort();
+			abortReference.current = null;
 		};
 	}, [dispatch, createFetch, id]);
 
@@ -74,13 +77,17 @@ const useFetchById = <TData,>({
 		};
 	}, []);
 
+	// Error/loading are gated to the CURRENT id: a REJECTED status left over from
+	// a previous id must not flash as an error on the next one before its fetch
+	// starts.
 	const isMatched = id !== undefined && loadedId === id;
-	const isLoading = id !== undefined && !isMatched && status !== DataStatus.REJECTED;
-	const hasError = id !== undefined && status === DataStatus.REJECTED;
+	const isErrorForCurrentId =
+		id !== undefined && status === DataStatus.REJECTED && attemptedIdReference.current === id;
+	const isLoading = id !== undefined && !isMatched && !isErrorForCurrentId;
 
 	return {
 		data: isMatched ? data : null,
-		hasError,
+		hasError: isErrorForCurrentId,
 		isLoading,
 	};
 };

--- a/src/libs/hooks/use-game-fetch/use-game-fetch.hook.ts
+++ b/src/libs/hooks/use-game-fetch/use-game-fetch.hook.ts
@@ -1,11 +1,6 @@
-import { useCallback, useEffect } from "react";
-
-import { DataStatus } from "~/libs/enums/enums";
-import { useAppDispatch } from "~/libs/hooks/use-app-dispatch/use-app-dispatch.hook";
-import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
-import { useLanguageSync } from "~/libs/hooks/use-language-sync/use-language-sync.hook";
+import { useFetchById } from "~/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook";
 import { type GameDescriptionDto } from "~/libs/types/types";
-import { actions as gamesActions } from "~/modules/games/slices/games";
+import { getById } from "~/modules/games/slices/actions";
 
 type UseGameFetchReturn = {
 	currentGame: GameDescriptionDto | null;
@@ -13,31 +8,16 @@ type UseGameFetchReturn = {
 };
 
 const useGameFetch = (id: string | undefined): UseGameFetchReturn => {
-	const dispatch = useAppDispatch();
-	const currentGame = useAppSelector((state) => state.games.currentGame);
-	const currentGameStatus = useAppSelector((state) => state.games.currentGameStatus);
-
-	const fetchGame = useCallback(() => {
-		if (id) {
-			void dispatch(gamesActions.getById(id));
-		}
-	}, [dispatch, id]);
-
-	useLanguageSync(fetchGame);
-
-	useEffect(() => {
-		if (!id || currentGame?.id === id) {
-			return;
-		}
-
-		fetchGame();
-	}, [id, currentGame?.id, fetchGame]);
-
-	const matchedGame = currentGame?.id === id ? currentGame : null;
-	const isLoading = matchedGame === null && currentGameStatus !== DataStatus.REJECTED;
+	const { data, isLoading } = useFetchById<GameDescriptionDto>({
+		createFetch: getById,
+		id,
+		selectData: (state) => state.games.currentGame,
+		selectLoadedId: (state) => state.games.currentGame?.id ?? null,
+		selectStatus: (state) => state.games.currentGameStatus,
+	});
 
 	return {
-		currentGame: matchedGame,
+		currentGame: data,
 		isLoading,
 	};
 };

--- a/src/libs/hooks/use-game-fetch/use-game-fetch.hook.ts
+++ b/src/libs/hooks/use-game-fetch/use-game-fetch.hook.ts
@@ -4,11 +4,12 @@ import { getById } from "~/modules/games/slices/actions";
 
 type UseGameFetchReturn = {
 	currentGame: GameDescriptionDto | null;
+	hasError: boolean;
 	isLoading: boolean;
 };
 
 const useGameFetch = (id: string | undefined): UseGameFetchReturn => {
-	const { data, isLoading } = useFetchById<GameDescriptionDto>({
+	const { data, hasError, isLoading } = useFetchById<GameDescriptionDto>({
 		createFetch: getById,
 		id,
 		selectData: (state) => state.games.currentGame,
@@ -18,6 +19,7 @@ const useGameFetch = (id: string | undefined): UseGameFetchReturn => {
 
 	return {
 		currentGame: data,
+		hasError,
 		isLoading,
 	};
 };

--- a/src/libs/hooks/use-levels-fetch/use-levels-fetch.hook.ts
+++ b/src/libs/hooks/use-levels-fetch/use-levels-fetch.hook.ts
@@ -1,41 +1,24 @@
-import { useCallback, useEffect } from "react";
-
-import { DataStatus } from "~/libs/enums/enums";
-import { useAppDispatch } from "~/libs/hooks/use-app-dispatch/use-app-dispatch.hook";
-import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
-import { useLanguageSync } from "~/libs/hooks/use-language-sync/use-language-sync.hook";
+import { useFetchById } from "~/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook";
+import { type LevelDescriptionDto } from "~/libs/types/types";
 import { getLevelsList } from "~/modules/games/slices/actions";
 
 type UseLevelsFetchReturn = {
 	isLoading: boolean;
+	levels: LevelDescriptionDto[] | null;
 };
 
 const useLevelsFetch = (id: string | undefined): UseLevelsFetchReturn => {
-	const dispatch = useAppDispatch();
-	const levelsStatus = useAppSelector((state) => state.games.levelsStatus);
-	const currentLevelsGameId = useAppSelector((state) => state.games.currentLevelsGameId);
-
-	const fetchLevels = useCallback(() => {
-		if (id) {
-			void dispatch(getLevelsList(id));
-		}
-	}, [dispatch, id]);
-
-	useLanguageSync(fetchLevels);
-
-	useEffect(() => {
-		if (!id || currentLevelsGameId === id) {
-			return;
-		}
-
-		fetchLevels();
-	}, [id, currentLevelsGameId, fetchLevels]);
-
-	const isMatched = id !== undefined && currentLevelsGameId === id;
-	const isLoading = !isMatched && levelsStatus !== DataStatus.REJECTED;
+	const { data, isLoading } = useFetchById<LevelDescriptionDto[]>({
+		createFetch: getLevelsList,
+		id,
+		selectData: (state) => state.games.currentGameLevels,
+		selectLoadedId: (state) => state.games.currentLevelsGameId,
+		selectStatus: (state) => state.games.levelsStatus,
+	});
 
 	return {
 		isLoading,
+		levels: data,
 	};
 };
 

--- a/src/libs/hooks/use-levels-fetch/use-levels-fetch.hook.ts
+++ b/src/libs/hooks/use-levels-fetch/use-levels-fetch.hook.ts
@@ -3,12 +3,13 @@ import { type LevelDescriptionDto } from "~/libs/types/types";
 import { getLevelsList } from "~/modules/games/slices/actions";
 
 type UseLevelsFetchReturn = {
+	hasError: boolean;
 	isLoading: boolean;
 	levels: LevelDescriptionDto[] | null;
 };
 
 const useLevelsFetch = (id: string | undefined): UseLevelsFetchReturn => {
-	const { data, isLoading } = useFetchById<LevelDescriptionDto[]>({
+	const { data, hasError, isLoading } = useFetchById<LevelDescriptionDto[]>({
 		createFetch: getLevelsList,
 		id,
 		selectData: (state) => state.games.currentGameLevels,
@@ -17,6 +18,7 @@ const useLevelsFetch = (id: string | undefined): UseLevelsFetchReturn => {
 	});
 
 	return {
+		hasError,
 		isLoading,
 		levels: data,
 	};

--- a/src/libs/modules/localization/locales/en/games.ts
+++ b/src/libs/modules/localization/locales/en/games.ts
@@ -2,6 +2,7 @@ const games = {
 	content: {
 		errorTitle: "Error",
 		invalidId: "Invalid or missing game ID.",
+		loadError: "Failed to load the game. Please try again.",
 		notFound: "Game content not found.",
 	},
 	findTheWrong: {

--- a/src/libs/modules/localization/locales/es/games.ts
+++ b/src/libs/modules/localization/locales/es/games.ts
@@ -2,6 +2,7 @@ const games = {
 	content: {
 		errorTitle: "Error",
 		invalidId: "ID de juego no válido o ausente.",
+		loadError: "No se pudo cargar el juego. Inténtalo de nuevo.",
 		notFound: "Contenido del juego no encontrado.",
 	},
 	findTheWrong: {

--- a/src/libs/modules/localization/locales/uk/games.ts
+++ b/src/libs/modules/localization/locales/uk/games.ts
@@ -2,6 +2,7 @@ const games = {
 	content: {
 		errorTitle: "Помилка",
 		invalidId: "Недійсний або відсутній ID гри.",
+		loadError: "Не вдалося завантажити гру. Будь ласка, спробуйте ще раз.",
 		notFound: "Контент гри не знайдено.",
 	},
 	findTheWrong: {

--- a/src/modules/games/slices/games.slice.ts
+++ b/src/modules/games/slices/games.slice.ts
@@ -45,7 +45,11 @@ const { actions, name, reducer } = createSlice({
 			state.currentGameStatus = DataStatus.FULFILLED;
 			state.currentGame = action.payload;
 		});
-		builder.addCase(getById.rejected, (state) => {
+		builder.addCase(getById.rejected, (state, action) => {
+			if (action.meta.aborted) {
+				return;
+			}
+
 			state.currentGameStatus = DataStatus.REJECTED;
 		});
 		builder.addCase(getLevelsList.pending, (state) => {
@@ -56,7 +60,11 @@ const { actions, name, reducer } = createSlice({
 			state.currentGameLevels = action.payload;
 			state.currentLevelsGameId = action.meta.arg;
 		});
-		builder.addCase(getLevelsList.rejected, (state) => {
+		builder.addCase(getLevelsList.rejected, (state, action) => {
+			if (action.meta.aborted) {
+				return;
+			}
+
 			state.levelsStatus = DataStatus.REJECTED;
 		});
 	},

--- a/src/pages/game-content-page/game-content-page.tsx
+++ b/src/pages/game-content-page/game-content-page.tsx
@@ -8,7 +8,7 @@ const GameContentPage: React.FC = () => {
 	const { t } = useTranslation();
 	const { id } = useParams();
 	const { currentGame, isLoading: isGameLoading } = useGameFetch(id);
-	const { isLoading: isLevelsLoading, levels } = useLevelsFetch(id);
+	const { hasError: hasLevelsError, isLoading: isLevelsLoading, levels } = useLevelsFetch(id);
 
 	const renderError = (message: string): React.JSX.Element => (
 		<div className={styles["game-content-page__error-container"]}>
@@ -35,7 +35,7 @@ const GameContentPage: React.FC = () => {
 		return renderError(t("games.content.notFound"));
 	}
 
-	return <GameLevelsPreview game={currentGame} levels={levels} />;
+	return <GameLevelsPreview game={currentGame} hasError={hasLevelsError} levels={levels} />;
 };
 
 export { GameContentPage };

--- a/src/pages/game-content-page/game-content-page.tsx
+++ b/src/pages/game-content-page/game-content-page.tsx
@@ -7,7 +7,7 @@ import styles from "./styles.module.css";
 const GameContentPage: React.FC = () => {
 	const { t } = useTranslation();
 	const { id } = useParams();
-	const { currentGame, isLoading: isGameLoading } = useGameFetch(id);
+	const { currentGame, hasError: hasGameError, isLoading: isGameLoading } = useGameFetch(id);
 	const { hasError: hasLevelsError, isLoading: isLevelsLoading, levels } = useLevelsFetch(id);
 
 	const renderError = (message: string): React.JSX.Element => (
@@ -29,6 +29,10 @@ const GameContentPage: React.FC = () => {
 
 	if (isPageLoading) {
 		return <Loader variant="page" />;
+	}
+
+	if (hasGameError) {
+		return renderError(t("games.content.loadError"));
 	}
 
 	if (!currentGame) {

--- a/src/pages/game-content-page/game-content-page.tsx
+++ b/src/pages/game-content-page/game-content-page.tsx
@@ -8,7 +8,7 @@ const GameContentPage: React.FC = () => {
 	const { t } = useTranslation();
 	const { id } = useParams();
 	const { currentGame, isLoading: isGameLoading } = useGameFetch(id);
-	const { isLoading: isLevelsLoading } = useLevelsFetch(id);
+	const { isLoading: isLevelsLoading, levels } = useLevelsFetch(id);
 
 	const renderError = (message: string): React.JSX.Element => (
 		<div className={styles["game-content-page__error-container"]}>
@@ -35,7 +35,7 @@ const GameContentPage: React.FC = () => {
 		return renderError(t("games.content.notFound"));
 	}
 
-	return <GameLevelsPreview game={currentGame} />;
+	return <GameLevelsPreview game={currentGame} levels={levels} />;
 };
 
 export { GameContentPage };

--- a/tests/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.spec.ts
+++ b/tests/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.spec.ts
@@ -136,13 +136,30 @@ describe("useFetchById", () => {
 		expect(result.current.isLoading).toBe(false);
 	});
 
-	it("reports an error and stops loading on rejection", () => {
-		setMockState({ data: null, loadedId: null, status: DataStatus.REJECTED });
+	it("reports an error and stops loading when the current id's fetch rejects", () => {
+		// Realistic transition: the fetch runs (PENDING) — marking the attempted
+		// id — then rejects, so the error is attributed to the current id.
+		setMockState({ data: null, loadedId: null, status: DataStatus.PENDING });
+		const { rerender, result } = renderFetchById("1");
 
-		const { result } = renderFetchById("1");
+		setMockState({ data: null, loadedId: null, status: DataStatus.REJECTED });
+		rerender("1");
 
 		expect(result.current.isLoading).toBe(false);
 		expect(result.current.hasError).toBe(true);
+	});
+
+	it("does not attribute a REJECTED status from another id to a matched id", () => {
+		// Levels for "2" are cached (matched), but the global status is REJECTED
+		// from a later, different id's failed fetch. The matched data must show
+		// without a spurious error.
+		setMockState({ data: "game-2", loadedId: "2", status: DataStatus.REJECTED });
+
+		const { result } = renderFetchById("2");
+
+		expect(result.current.data).toBe("game-2");
+		expect(result.current.hasError).toBe(false);
+		expect(result.current.isLoading).toBe(false);
 	});
 
 	it("registers a language-sync callback that refetches", () => {

--- a/tests/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.spec.ts
+++ b/tests/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.spec.ts
@@ -52,7 +52,7 @@ const setMockState = (state: TestState): void => {
 
 const createFetch = vi.fn((id: string) => ({ id, type: "test/fetch" }));
 
-const renderFetchById = (id: string | undefined) =>
+const renderFetchById = (id?: string) =>
 	renderHook((current: string | undefined) =>
 		useFetchById<string>({
 			createFetch: createFetch as never,
@@ -76,6 +76,7 @@ describe("useFetchById", () => {
 		expect(createFetch).toHaveBeenCalledWith("1");
 		expect(result.current.data).toBeNull();
 		expect(result.current.isLoading).toBe(true);
+		expect(result.current.hasError).toBe(false);
 	});
 
 	it("does not fetch when cached id already matches", () => {
@@ -86,6 +87,7 @@ describe("useFetchById", () => {
 		expect(createFetch).not.toHaveBeenCalled();
 		expect(result.current.data).toBe("game-1");
 		expect(result.current.isLoading).toBe(false);
+		expect(result.current.hasError).toBe(false);
 	});
 
 	it("refetches when the id changes", () => {
@@ -134,12 +136,13 @@ describe("useFetchById", () => {
 		expect(result.current.isLoading).toBe(false);
 	});
 
-	it("stops loading on rejection", () => {
+	it("reports an error and stops loading on rejection", () => {
 		setMockState({ data: null, loadedId: null, status: DataStatus.REJECTED });
 
 		const { result } = renderFetchById("1");
 
 		expect(result.current.isLoading).toBe(false);
+		expect(result.current.hasError).toBe(true);
 	});
 
 	it("registers a language-sync callback that refetches", () => {

--- a/tests/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.spec.ts
+++ b/tests/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DataStatus } from "~/libs/enums/enums";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockAbort, mockDispatch, mockUseLanguageSync } = vi.hoisted(() => {
+	const mockAbort = vi.fn();
+	const mockDispatch = vi.fn(() => ({ abort: mockAbort }));
+	const mockUseLanguageSync = vi.fn<(callback: () => void) => void>();
+
+	return { mockAbort, mockDispatch, mockUseLanguageSync };
+});
+
+vi.mock("~/libs/hooks/use-app-dispatch/use-app-dispatch.hook", () => ({
+	useAppDispatch: (): typeof mockDispatch => mockDispatch,
+}));
+
+vi.mock("~/libs/hooks/use-app-selector/use-app-selector.hook", () => ({
+	useAppSelector: vi.fn(),
+}));
+
+vi.mock("~/libs/hooks/use-language-sync/use-language-sync.hook", () => ({
+	useLanguageSync: mockUseLanguageSync,
+}));
+
+// ─── Imports (after vi.mock calls) ───────────────────────────────────────────
+
+import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
+import { useFetchById } from "~/libs/hooks/use-fetch-by-id/use-fetch-by-id.hook";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockUseAppSelector = vi.mocked(useAppSelector);
+
+type TestState = {
+	data: null | string;
+	loadedId: null | string;
+	status: (typeof DataStatus)[keyof typeof DataStatus];
+};
+
+const setMockState = (state: TestState): void => {
+	mockUseAppSelector.mockImplementation((selector) =>
+		selector(state as unknown as Parameters<typeof selector>[0])
+	);
+};
+
+const createFetch = vi.fn((id: string) => ({ id, type: "test/fetch" }));
+
+const renderFetchById = (id: string | undefined) =>
+	renderHook((current: string | undefined) =>
+		useFetchById<string>({
+			createFetch: createFetch as never,
+			id: current,
+			selectData: (state) => (state as unknown as TestState).data,
+			selectLoadedId: (state) => (state as unknown as TestState).loadedId,
+			selectStatus: (state) => (state as unknown as TestState).status,
+		}),
+	{ initialProps: id });
+
+describe("useFetchById", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("fetches on mount when nothing is cached", () => {
+		setMockState({ data: null, loadedId: null, status: DataStatus.IDLE });
+
+		const { result } = renderFetchById("1");
+
+		expect(createFetch).toHaveBeenCalledWith("1");
+		expect(result.current.data).toBeNull();
+		expect(result.current.isLoading).toBe(true);
+	});
+
+	it("does not fetch when cached id already matches", () => {
+		setMockState({ data: "game-1", loadedId: "1", status: DataStatus.FULFILLED });
+
+		const { result } = renderFetchById("1");
+
+		expect(createFetch).not.toHaveBeenCalled();
+		expect(result.current.data).toBe("game-1");
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("refetches when the id changes", () => {
+		setMockState({ data: "game-1", loadedId: "1", status: DataStatus.FULFILLED });
+
+		const { rerender } = renderFetchById("1");
+		rerender("2");
+
+		expect(createFetch).toHaveBeenCalledWith("2");
+	});
+
+	it("aborts the previous in-flight request before refetching", () => {
+		setMockState({ data: null, loadedId: null, status: DataStatus.IDLE });
+
+		const { rerender } = renderFetchById("1");
+		rerender("2");
+
+		expect(mockAbort).toHaveBeenCalled();
+	});
+
+	it("aborts the in-flight request on unmount", () => {
+		setMockState({ data: null, loadedId: null, status: DataStatus.IDLE });
+
+		const { unmount } = renderFetchById("1");
+		unmount();
+
+		expect(mockAbort).toHaveBeenCalled();
+	});
+
+	it("never exposes data cached for a different id", () => {
+		setMockState({ data: "game-1", loadedId: "1", status: DataStatus.FULFILLED });
+
+		const { result } = renderFetchById("2");
+
+		expect(result.current.data).toBeNull();
+		expect(result.current.isLoading).toBe(true);
+	});
+
+	it("treats undefined id as not loading and does not fetch", () => {
+		setMockState({ data: "game-1", loadedId: "1", status: DataStatus.FULFILLED });
+
+		const { result } = renderFetchById();
+
+		expect(createFetch).not.toHaveBeenCalled();
+		expect(result.current.data).toBeNull();
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("stops loading on rejection", () => {
+		setMockState({ data: null, loadedId: null, status: DataStatus.REJECTED });
+
+		const { result } = renderFetchById("1");
+
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("registers a language-sync callback that refetches", () => {
+		setMockState({ data: "game-1", loadedId: "1", status: DataStatus.FULFILLED });
+
+		let capturedCallback: (() => void) | undefined;
+		mockUseLanguageSync.mockImplementation((callback: () => void) => {
+			capturedCallback = callback;
+		});
+
+		renderFetchById("1");
+
+		expect(capturedCallback).toBeDefined();
+
+		act(() => {
+			capturedCallback?.();
+		});
+
+		expect(createFetch).toHaveBeenCalledWith("1");
+	});
+});

--- a/tests/libs/hooks/use-game-fetch/use-game-fetch.hook.spec.ts
+++ b/tests/libs/hooks/use-game-fetch/use-game-fetch.hook.spec.ts
@@ -1,26 +1,26 @@
 /**
  * @vitest-environment jsdom
+ *
+ * Thin-wrapper tests: full fetch-by-id logic (abort, undefined id, refetch) is
+ * covered in use-fetch-by-id.hook.spec. Here we only verify the wiring —
+ * getById as the action, the game selectors, and the data→currentGame rename.
  */
 import { renderHook } from "@testing-library/react";
-import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DataStatus } from "~/libs/enums/enums";
 import { type GameDescriptionDto, type ValueOf } from "~/libs/types/types";
 
-// ─── Hoisted mocks ────────────────────────────────────────────────────────────
-
 const { mockDispatch, mockGetById, mockUseLanguageSync } = vi.hoisted(() => {
-	const mockGetById = vi.fn((id: string) => ({ payload: id, type: "games/get-by-id" }));
-	const mockDispatch = vi.fn();
+	const mockAbort = vi.fn();
+	const mockDispatch = vi.fn(() => ({ abort: mockAbort }));
+	const mockGetById = vi.fn((id: string) => ({ id, type: "games/get-by-id" }));
 	const mockUseLanguageSync = vi.fn<(callback: () => void) => void>();
 
 	return { mockDispatch, mockGetById, mockUseLanguageSync };
 });
 
-vi.mock("~/modules/games/slices/games", () => ({
-	actions: { getById: mockGetById },
-}));
+vi.mock("~/modules/games/slices/actions", () => ({ getById: mockGetById }));
 
 vi.mock("~/libs/hooks/use-app-dispatch/use-app-dispatch.hook", () => ({
 	useAppDispatch: (): typeof mockDispatch => mockDispatch,
@@ -34,12 +34,8 @@ vi.mock("~/libs/hooks/use-language-sync/use-language-sync.hook", () => ({
 	useLanguageSync: mockUseLanguageSync,
 }));
 
-// ─── Imports (after vi.mock calls) ───────────────────────────────────────────
-
 import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
 import { useGameFetch } from "~/libs/hooks/use-game-fetch/use-game-fetch.hook";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockUseAppSelector = vi.mocked(useAppSelector);
 
@@ -62,86 +58,35 @@ const setMockState = (state: GamesState): void => {
 	);
 };
 
-const renderGameFetch = (id: string | undefined) =>
-	renderHook((current: string | undefined) => useGameFetch(current), { initialProps: id });
-
 describe("useGameFetch", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("fetches on mount when no game is cached", () => {
+	it("fetches the game via getById when uncached", () => {
 		setMockState({ currentGame: null, currentGameStatus: DataStatus.IDLE });
 
-		const { result } = renderGameFetch("1");
+		const { result } = renderHook(() => useGameFetch("5"));
 
-		expect(mockGetById).toHaveBeenCalledWith("1");
-		expect(result.current.isLoading).toBe(true);
-		expect(result.current.currentGame).toBeNull();
+		expect(mockGetById).toHaveBeenCalledWith("5");
+		expect(result.current).toEqual({ currentGame: null, isLoading: true });
 	});
 
-	it("does not refetch when the cached game already matches the id", () => {
-		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
+	it("returns the matched game without refetching", () => {
+		setMockState({ currentGame: makeGame("5"), currentGameStatus: DataStatus.FULFILLED });
 
-		const { result } = renderGameFetch("1");
+		const { result } = renderHook(() => useGameFetch("5"));
 
 		expect(mockGetById).not.toHaveBeenCalled();
-		expect(result.current.isLoading).toBe(false);
-		expect(result.current.currentGame).toEqual(makeGame("1"));
+		expect(result.current).toEqual({ currentGame: makeGame("5"), isLoading: false });
 	});
 
-	it("does not dispatch again on rerender with the same id", () => {
+	it("hides a game cached for a different id", () => {
 		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
 
-		const { rerender } = renderGameFetch("1");
-		rerender("1");
-
-		expect(mockGetById).not.toHaveBeenCalled();
-	});
-
-	it("refetches when the id changes to a game that is not cached", () => {
-		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
-
-		const { rerender } = renderGameFetch("1");
-		rerender("2");
-
-		expect(mockGetById).toHaveBeenCalledWith("2");
-	});
-
-	it("treats a cached game from a different id as loading (no stale data exposed)", () => {
-		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
-
-		const { result } = renderGameFetch("2");
+		const { result } = renderHook(() => useGameFetch("2"));
 
 		expect(result.current.currentGame).toBeNull();
 		expect(result.current.isLoading).toBe(true);
-	});
-
-	it("stops loading on rejection so the consumer can show not-found", () => {
-		setMockState({ currentGame: null, currentGameStatus: DataStatus.REJECTED });
-
-		const { result } = renderGameFetch("1");
-
-		expect(result.current.currentGame).toBeNull();
-		expect(result.current.isLoading).toBe(false);
-	});
-
-	it("registers a language-sync callback that refetches the game", () => {
-		setMockState({ currentGame: makeGame("1"), currentGameStatus: DataStatus.FULFILLED });
-
-		let capturedCallback: (() => void) | undefined;
-		mockUseLanguageSync.mockImplementation((callback: () => void) => {
-			capturedCallback = callback;
-		});
-
-		renderGameFetch("1");
-
-		expect(capturedCallback).toBeDefined();
-
-		act(() => {
-			capturedCallback?.();
-		});
-
-		expect(mockGetById).toHaveBeenCalledWith("1");
 	});
 });

--- a/tests/libs/hooks/use-game-fetch/use-game-fetch.hook.spec.ts
+++ b/tests/libs/hooks/use-game-fetch/use-game-fetch.hook.spec.ts
@@ -69,7 +69,7 @@ describe("useGameFetch", () => {
 		const { result } = renderHook(() => useGameFetch("5"));
 
 		expect(mockGetById).toHaveBeenCalledWith("5");
-		expect(result.current).toEqual({ currentGame: null, isLoading: true });
+		expect(result.current).toEqual({ currentGame: null, hasError: false, isLoading: true });
 	});
 
 	it("returns the matched game without refetching", () => {
@@ -78,7 +78,7 @@ describe("useGameFetch", () => {
 		const { result } = renderHook(() => useGameFetch("5"));
 
 		expect(mockGetById).not.toHaveBeenCalled();
-		expect(result.current).toEqual({ currentGame: makeGame("5"), isLoading: false });
+		expect(result.current).toEqual({ currentGame: makeGame("5"), hasError: false, isLoading: false });
 	});
 
 	it("hides a game cached for a different id", () => {

--- a/tests/libs/hooks/use-levels-fetch/use-levels-fetch.hook.spec.ts
+++ b/tests/libs/hooks/use-levels-fetch/use-levels-fetch.hook.spec.ts
@@ -1,25 +1,26 @@
 /**
  * @vitest-environment jsdom
+ *
+ * Thin-wrapper tests: full fetch-by-id logic is covered in
+ * use-fetch-by-id.hook.spec. Here we only verify the wiring — getLevelsList as
+ * the action, the level selectors, and the data→levels rename.
  */
 import { renderHook } from "@testing-library/react";
-import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DataStatus } from "~/libs/enums/enums";
-
-// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+import { type LevelDescriptionDto, type ValueOf } from "~/libs/types/types";
 
 const { mockDispatch, mockGetLevelsList, mockUseLanguageSync } = vi.hoisted(() => {
-	const mockGetLevelsList = vi.fn((id: string) => ({ payload: id, type: "games/get-levels" }));
-	const mockDispatch = vi.fn();
+	const mockAbort = vi.fn();
+	const mockDispatch = vi.fn(() => ({ abort: mockAbort }));
+	const mockGetLevelsList = vi.fn((id: string) => ({ id, type: "games/get-levels" }));
 	const mockUseLanguageSync = vi.fn<(callback: () => void) => void>();
 
 	return { mockDispatch, mockGetLevelsList, mockUseLanguageSync };
 });
 
-vi.mock("~/modules/games/slices/actions", () => ({
-	getLevelsList: mockGetLevelsList,
-}));
+vi.mock("~/modules/games/slices/actions", () => ({ getLevelsList: mockGetLevelsList }));
 
 vi.mock("~/libs/hooks/use-app-dispatch/use-app-dispatch.hook", () => ({
 	useAppDispatch: (): typeof mockDispatch => mockDispatch,
@@ -33,19 +34,18 @@ vi.mock("~/libs/hooks/use-language-sync/use-language-sync.hook", () => ({
 	useLanguageSync: mockUseLanguageSync,
 }));
 
-// ─── Imports (after vi.mock calls) ───────────────────────────────────────────
-
 import { useAppSelector } from "~/libs/hooks/use-app-selector/use-app-selector.hook";
 import { useLevelsFetch } from "~/libs/hooks/use-levels-fetch/use-levels-fetch.hook";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const mockUseAppSelector = vi.mocked(useAppSelector);
 
 type GamesState = {
+	currentGameLevels: LevelDescriptionDto[] | null;
 	currentLevelsGameId: null | string;
-	levelsStatus: (typeof DataStatus)[keyof typeof DataStatus];
+	levelsStatus: ValueOf<typeof DataStatus>;
 };
+
+const LEVELS = [{ id: 10 }] as unknown as LevelDescriptionDto[];
 
 const setMockState = (state: GamesState): void => {
 	mockUseAppSelector.mockImplementation((selector) =>
@@ -53,82 +53,47 @@ const setMockState = (state: GamesState): void => {
 	);
 };
 
-const renderLevelsFetch = (id: string | undefined) =>
-	renderHook((current: string | undefined) => useLevelsFetch(current), { initialProps: id });
-
 describe("useLevelsFetch", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("fetches on mount when no levels are cached", () => {
-		setMockState({ currentLevelsGameId: null, levelsStatus: DataStatus.IDLE });
-
-		const { result } = renderLevelsFetch("1");
-
-		expect(mockGetLevelsList).toHaveBeenCalledWith("1");
-		expect(result.current.isLoading).toBe(true);
-	});
-
-	it("does not refetch when cached levels already belong to the id", () => {
-		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
-
-		const { result } = renderLevelsFetch("1");
-
-		expect(mockGetLevelsList).not.toHaveBeenCalled();
-		expect(result.current.isLoading).toBe(false);
-	});
-
-	it("does not dispatch again on rerender with the same id", () => {
-		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
-
-		const { rerender } = renderLevelsFetch("1");
-		rerender("1");
-
-		expect(mockGetLevelsList).not.toHaveBeenCalled();
-	});
-
-	it("refetches when the id changes to a game whose levels are not cached", () => {
-		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
-
-		const { rerender } = renderLevelsFetch("1");
-		rerender("2");
-
-		expect(mockGetLevelsList).toHaveBeenCalledWith("2");
-	});
-
-	it("treats levels cached for a different id as loading (no stale levels exposed)", () => {
-		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
-
-		const { result } = renderLevelsFetch("2");
-
-		expect(result.current.isLoading).toBe(true);
-	});
-
-	it("stops loading on rejection so the consumer can show an error", () => {
-		setMockState({ currentLevelsGameId: null, levelsStatus: DataStatus.REJECTED });
-
-		const { result } = renderLevelsFetch("1");
-
-		expect(result.current.isLoading).toBe(false);
-	});
-
-	it("registers a language-sync callback that refetches the levels", () => {
-		setMockState({ currentLevelsGameId: "1", levelsStatus: DataStatus.FULFILLED });
-
-		let capturedCallback: (() => void) | undefined;
-		mockUseLanguageSync.mockImplementation((callback: () => void) => {
-			capturedCallback = callback;
+	it("fetches levels via getLevelsList when uncached", () => {
+		setMockState({
+			currentGameLevels: null,
+			currentLevelsGameId: null,
+			levelsStatus: DataStatus.IDLE,
 		});
 
-		renderLevelsFetch("1");
+		const { result } = renderHook(() => useLevelsFetch("5"));
 
-		expect(capturedCallback).toBeDefined();
+		expect(mockGetLevelsList).toHaveBeenCalledWith("5");
+		expect(result.current).toEqual({ isLoading: true, levels: null });
+	});
 
-		act(() => {
-			capturedCallback?.();
+	it("returns matched levels without refetching", () => {
+		setMockState({
+			currentGameLevels: LEVELS,
+			currentLevelsGameId: "5",
+			levelsStatus: DataStatus.FULFILLED,
 		});
 
-		expect(mockGetLevelsList).toHaveBeenCalledWith("1");
+		const { result } = renderHook(() => useLevelsFetch("5"));
+
+		expect(mockGetLevelsList).not.toHaveBeenCalled();
+		expect(result.current).toEqual({ isLoading: false, levels: LEVELS });
+	});
+
+	it("hides levels cached for a different id", () => {
+		setMockState({
+			currentGameLevels: LEVELS,
+			currentLevelsGameId: "1",
+			levelsStatus: DataStatus.FULFILLED,
+		});
+
+		const { result } = renderHook(() => useLevelsFetch("2"));
+
+		expect(result.current.levels).toBeNull();
+		expect(result.current.isLoading).toBe(true);
 	});
 });

--- a/tests/libs/hooks/use-levels-fetch/use-levels-fetch.hook.spec.ts
+++ b/tests/libs/hooks/use-levels-fetch/use-levels-fetch.hook.spec.ts
@@ -68,7 +68,7 @@ describe("useLevelsFetch", () => {
 		const { result } = renderHook(() => useLevelsFetch("5"));
 
 		expect(mockGetLevelsList).toHaveBeenCalledWith("5");
-		expect(result.current).toEqual({ isLoading: true, levels: null });
+		expect(result.current).toEqual({ hasError: false, isLoading: true, levels: null });
 	});
 
 	it("returns matched levels without refetching", () => {
@@ -81,7 +81,7 @@ describe("useLevelsFetch", () => {
 		const { result } = renderHook(() => useLevelsFetch("5"));
 
 		expect(mockGetLevelsList).not.toHaveBeenCalled();
-		expect(result.current).toEqual({ isLoading: false, levels: LEVELS });
+		expect(result.current).toEqual({ hasError: false, isLoading: false, levels: LEVELS });
 	});
 
 	it("hides levels cached for a different id", () => {

--- a/tests/modules/games/games.slice.spec.ts
+++ b/tests/modules/games/games.slice.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { DataStatus } from "~/libs/enums/enums";
+import { getById, getLevelsList } from "~/modules/games/slices/actions";
+import { reducer } from "~/modules/games/slices/games.slice";
+
+const initialState = {
+	currentGame: null,
+	currentGameLevels: null,
+	currentGameStatus: DataStatus.IDLE,
+	currentLevelsGameId: null,
+	games: [],
+	gamesStatus: DataStatus.IDLE,
+	levelsStatus: DataStatus.IDLE,
+};
+
+const pendingState = { ...initialState, currentGameStatus: DataStatus.PENDING };
+const levelsPendingState = { ...initialState, levelsStatus: DataStatus.PENDING };
+
+describe("games slice", () => {
+	it("returns the initial state", () => {
+		expect(reducer(undefined, { type: "UNKNOWN" })).toEqual(initialState);
+	});
+
+	it("records the loaded game id on getLevelsList.fulfilled (from meta.arg)", () => {
+		const state = reducer(levelsPendingState, {
+			meta: { arg: "5" },
+			payload: [{ id: 1 }],
+			type: getLevelsList.fulfilled.type,
+		});
+
+		expect(state.levelsStatus).toBe(DataStatus.FULFILLED);
+		expect(state.currentLevelsGameId).toBe("5");
+		expect(state.currentGameLevels).toEqual([{ id: 1 }]);
+	});
+
+	it("sets REJECTED on a real getById failure", () => {
+		const state = reducer(pendingState, {
+			meta: { aborted: false },
+			type: getById.rejected.type,
+		});
+
+		expect(state.currentGameStatus).toBe(DataStatus.REJECTED);
+	});
+
+	it("ignores an aborted getById rejection (no error flash)", () => {
+		const state = reducer(pendingState, {
+			meta: { aborted: true },
+			type: getById.rejected.type,
+		});
+
+		expect(state.currentGameStatus).toBe(DataStatus.PENDING);
+	});
+
+	it("sets REJECTED on a real getLevelsList failure", () => {
+		const state = reducer(levelsPendingState, {
+			meta: { aborted: false },
+			type: getLevelsList.rejected.type,
+		});
+
+		expect(state.levelsStatus).toBe(DataStatus.REJECTED);
+	});
+
+	it("ignores an aborted getLevelsList rejection (no error flash)", () => {
+		const state = reducer(levelsPendingState, {
+			meta: { aborted: true },
+			type: getLevelsList.rejected.type,
+		});
+
+		expect(state.levelsStatus).toBe(DataStatus.PENDING);
+	});
+});


### PR DESCRIPTION
- [x] Create a generic `useFetchById` (`src/libs/hooks/use-fetch-by-id/`).
- [x] Abort the previous in-flight thunk upon ID change or unmount (via `dispatch(...).abort()`; store the promise in a ref, perform an identity check before removal).
- [x] Rewrite `useGameFetch` as a thin wrapper; preserve the `{ currentGame, isLoading }` contract.
- [x] Rewrite `useLevelsFetch` as a thin wrapper; return `{ levels, isLoading }`.
- [x] `GameContentPage` + `GameLevelsPreview`: Pass levels via prop (remove direct `useAppSelector(currentGameLevels)` from preview).
- [x] Tests: generic hook (match/mismatch/abort), update `use-game-fetch`/`use-levels-fetch` specs for wrappers.