### PR TITLE
fix(config): drop dev-only VITE_APP_PROXY_SERVER_URL from runtime env validation ss-140

### DIFF
--- a/src/libs/modules/config/base-config.module.ts
+++ b/src/libs/modules/config/base-config.module.ts
@@ -10,7 +10,6 @@ class BaseConfig implements Config {
 		return {
 			API: {
 				ORIGIN_URL: import.meta.env.VITE_APP_API_ORIGIN_URL,
-				PROXY_SERVER_URL: import.meta.env.VITE_APP_PROXY_SERVER_URL,
 			},
 			APP: {
 				ENVIRONMENT: import.meta.env.VITE_APP_NODE_ENV,

--- a/src/libs/modules/config/libs/validation-schemas/environment.validation-schema.ts
+++ b/src/libs/modules/config/libs/validation-schemas/environment.validation-schema.ts
@@ -7,7 +7,6 @@ const REQUIRED_STRING_MIN_LENGTH = 1;
 const environmentValidationSchema = z.object({
 	API: z.object({
 		ORIGIN_URL: z.string().min(REQUIRED_STRING_MIN_LENGTH),
-		PROXY_SERVER_URL: z.string().min(REQUIRED_STRING_MIN_LENGTH),
 	}),
 	APP: z.object({
 		ENVIRONMENT: z.enum(AppEnvironment),

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,5 +4,4 @@
 interface ImportMetaEnv {
 	readonly VITE_APP_API_ORIGIN_URL: string;
 	readonly VITE_APP_NODE_ENV: string;
-	readonly VITE_APP_PROXY_SERVER_URL: string;
 }

--- a/tests/libs/modules/config/base-config.module.spec.ts
+++ b/tests/libs/modules/config/base-config.module.spec.ts
@@ -6,7 +6,6 @@ const stubEnvironment = (overrides: Record<string, string>): void => {
 	const defaults = {
 		VITE_APP_API_ORIGIN_URL: "https://api.example.com",
 		VITE_APP_NODE_ENV: "production",
-		VITE_APP_PROXY_SERVER_URL: "https://proxy.example.com",
 		...overrides,
 	};
 
@@ -26,8 +25,14 @@ describe("BaseConfig", () => {
 		const config = new BaseConfig();
 
 		expect(config.ENV.API.ORIGIN_URL).toBe("https://api.example.com");
-		expect(config.ENV.API.PROXY_SERVER_URL).toBe("https://proxy.example.com");
 		expect(config.ENV.APP.ENVIRONMENT).toBe("production");
+	});
+
+	it("does not require the dev-only proxy variable (absent in production builds)", () => {
+		stubEnvironment({});
+		vi.stubEnv("VITE_APP_PROXY_SERVER_URL", "");
+
+		expect(() => new BaseConfig()).not.toThrow();
 	});
 
 	it("throws when a required variable is empty", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,6 @@ const config = ({ mode }: ConfigEnv) => {
 			env: {
 				VITE_APP_API_ORIGIN_URL: "http://localhost:3000/api",
 				VITE_APP_NODE_ENV: "local",
-				VITE_APP_PROXY_SERVER_URL: "http://localhost:3002",
 			},
 		},
 	});


### PR DESCRIPTION
- [x] Remove PROXY_SERVER_URL from environment.validation-schema.ts (keep only API.ORIGIN_URL + APP.ENVIRONMENT)
- [x] Remove its read from base-config.module.ts rawEnvironment
- [x] Remove VITE_APP_PROXY_SERVER_URL from vite-env.d.ts and from the vitest test.env block (keep it in vite.config.ts dev proxy)
- [x] Update base-config.module.spec.ts: drop the proxy assertion + add a regression test that an absent/empty proxy var does not throw
- [x] Gates: typecheck + lint:ci + test:ci + npm run build